### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,6 +3,9 @@ name: pre-commit
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxcla/security/code-scanning/4](https://github.com/cvxgrp/cvxcla/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow does not appear to require write access to the repository or other elevated permissions, we will set the permissions to `contents: read` at the root level of the workflow. This ensures that all jobs in the workflow inherit the minimal permissions unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
