### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   marimo:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8
@@ -15,6 +17,8 @@ jobs:
 
   test:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8
@@ -24,6 +28,8 @@ jobs:
 
   jupyter:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8
@@ -32,6 +38,8 @@ jobs:
 
   pdoc:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxcla/security/code-scanning/6](https://github.com/cvxgrp/cvxcla/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to each job (`marimo`, `test`, `jupyter`, and `pdoc`) in the workflow file. These permissions will be set to the minimum required for the jobs to function correctly. Based on the provided information, most jobs likely only need `contents: read`. If any job requires additional permissions, they will be explicitly added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
