### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "CI"
 on:
 - push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # The type of runner that the job will run on


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxcla/security/code-scanning/1](https://github.com/cvxgrp/cvxcla/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it appears that the actions used (`cvxgrp/.github/actions/environment` and `cvxgrp/.github/actions/test`) likely only require read access to the repository contents. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
