### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     # Builds the Python package with the new version tag
     runs-on: ubuntu-latest
     needs: tagging  # Depends on the tagging job to get the new version
+    permissions:
+      contents: read
     steps:
       - name: build
         uses: tschm/cradle/actions/build@v0.2.1  # Use the build action to build the package


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxcla/security/code-scanning/9](https://github.com/cvxgrp/cvxcla/security/code-scanning/9)

To fix the issue, add a `permissions` block to the `build` job in the workflow file. The `build` job only needs read access to the repository contents to perform its tasks, so the permissions should be limited to `contents: read`. This ensures that the job adheres to the principle of least privilege and avoids unnecessary write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
