### PR TITLE
fix: add mkdocs.yml to set correct site name and repo for cvxcla

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+INHERIT: docs/mkdocs-base.yml
+
+site_name: cvxcla
+site_url: https://www.cvxgrp.org/cvxcla/
+repo_url: https://github.com/cvxgrp/cvxcla
+repo_name: cvxgrp/cvxcla
+
+docs_dir: docs
+
+theme:
+  name: material
+  logo: assets/rhiza-logo.svg
+  favicon: assets/rhiza-logo.svg
+
+nav:
+  - Home: index.md
+  - Notebooks: notebooks.md
+  - Reports: reports.md


### PR DESCRIPTION
The base template defaulted to site_name "Rhiza", making the published docs page show the wrong project name.