### PR TITLE
chore: update rhiza to v0.15.3

### DIFF
--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 8020ad01ac1ab64cfa5abb9915f44af9fbd0ede7
+sha: 4051814fc1976da3a86cefa499be5bada21eb674
 repo: jebel-quant/rhiza
 host: github
-ref: v0.15.2
+ref: v0.15.3
 include: []
 exclude: []
 templates:
@@ -102,5 +102,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-05-26T12:15:52Z'
+synced_at: '2026-05-26T14:41:06Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.15.2"
+ref: "v0.15.3"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary

- Bumps `template-branch` to `v0.15.3` in `.rhiza/template.yml`
- Bumps `.rhiza/.rhiza-version` to `0.16.1`
- Runs `make sync` to apply upstream template changes
