### PR TITLE
Quality roadmap: degeneracy fixes, property tests, doc and DX cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ Run the test suite with:
 make test
 ```
 
+or directly via pytest:
+
+```bash
+uv run pytest
+```
+
 ## 🧹 Code Quality
 
 Format and lint the code with:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 📈 [cvxcla](https://www.cvxgrp.org/cvxcla) - Critical Line Algorithm for Portfolio Optimization
 
 [![PyPI version](https://img.shields.io/pypi/v/cvxcla)](https://pypi.org/project/cvxcla/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/cvxcla?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/cvxcla)
 [![Coverage](https://www.cvxgrp.org/cvxcla/coverage-badge.svg)](https://www.cvxgrp.org/cvxcla/tests/html-coverage/index.html)
 
@@ -60,13 +60,11 @@ three steps:
 
 1. **Start** at λ = ∞, where the portfolio concentrates on the highest-return asset
    within bounds
-   ([`init_algo`](https://github.com/cvxgrp/cvxcla/blob/main/src/cvxcla/first.py),
-   called from [`_first_turning_point`](https://github.com/cvxgrp/cvxcla/blob/main/src/cvxcla/cla.py#L223)).
+   ([`init_algo`](https://github.com/cvxgrp/cvxcla/blob/main/src/cvxcla/first.py)).
 
-2. **Solve** the KKT system for the current active set to find α and β
-   ([`_solve`](https://github.com/cvxgrp/cvxcla/blob/main/src/cvxcla/cla.py#L189)),
-   then decrease λ until one of two events occurs
-   ([main loop](https://github.com/cvxgrp/cvxcla/blob/main/src/cvxcla/cla.py#L122)):
+2. **Solve** the KKT system for the current active set to find α and β by
+   block elimination, then decrease λ until one of two events occurs
+   (main loop in [`cla.py`](https://github.com/cvxgrp/cvxcla/blob/main/src/cvxcla/cla.py)):
    - a **free** asset hits its bound (leaves the free set), or
    - a **blocked** asset's KKT multiplier changes sign (enters the free set).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "numpy>=2.0.0",
 ]
 
-# add Philipp
 authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"},
            {name = "Philipp Schiele", email = "pschiele@stanford.edu"}]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
 test = [
     "pytest>=7.0",
     "pytest-timeout>=2.3",
+    "hypothesis>=6.100",
 ]
 lint = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,13 @@ dev = [
 ]
 test = [
     "pytest>=7.0",
+    "pytest-timeout>=2.3",
 ]
 lint = []
+
+# make a fresh `uv run pytest` work without knowing about dependency groups
+[tool.uv]
+default-groups = ["dev", "test"]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -253,13 +253,14 @@ class CLA:
 
         Args:
             tp: The turning point to append.
-            tol: Tolerance for constraint validation. If None, uses the class's tol attribute.
+            tol: Tolerance for constraint validation. If None, uses the class's
+                tol attribute. Pass 0 for exact validation.
 
         Raises:
-            AssertionError: If the turning point violates any constraints.
+            ValueError: If the turning point violates any constraints.
 
         """
-        tol = tol or self.tol
+        tol = self.tol if tol is None else tol
 
         if not np.all(tp.weights >= (self.lower_bounds - tol)):
             msg = "Weights below lower bounds"

--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -106,6 +106,7 @@ class CLA:
         m = self.a.shape[0]
         ns = len(self.mean)
         cov = self.covariance_operator
+        tol = self.tol
 
         # Compute and store the first turning point
         self._append(self._first_turning_point())
@@ -121,8 +122,8 @@ class CLA:
                 msg = "All variables cannot be blocked"
                 raise RuntimeError(msg)
 
-            at_upper = blocked & np.isclose(last.weights, self.upper_bounds)
-            at_lower = blocked & np.isclose(last.weights, self.lower_bounds)
+            at_upper = blocked & (np.abs(last.weights - self.upper_bounds) <= tol)
+            at_lower = blocked & (np.abs(last.weights - self.lower_bounds) <= tol)
 
             _out = at_upper | at_lower
             _in = ~_out
@@ -166,23 +167,45 @@ class CLA:
             delta = cov.matvec(r_beta) + self.a.T @ nu_beta - self.mean
 
             # --- Compute event ratios ---
+            # A free weight moves along w(lam) = r_alpha + lam * r_beta, so even
+            # a tiny slope crosses a bound given a long enough lam range.
+            # Filtering slopes at self.tol misses such crossings and lets
+            # weights drift out of bounds; only slopes at floating-point noise
+            # level are excluded: below sqrt(machine epsilon) a slope is
+            # indistinguishable from solve noise, and the huge ratios it would
+            # produce only amplify rounding errors. Spurious ratios above the
+            # current lam are removed by the lam window below.
+            eps = np.sqrt(np.finfo(np.float64).eps)
             l_mat = np.full((ns, 4), -np.inf)
-            tol = self.tol
 
-            l_mat[_in & (r_beta < -tol), 0] = (
-                self.upper_bounds[_in & (r_beta < -tol)] - r_alpha[_in & (r_beta < -tol)]
-            ) / r_beta[_in & (r_beta < -tol)]
-            l_mat[_in & (r_beta > +tol), 1] = (
-                self.lower_bounds[_in & (r_beta > +tol)] - r_alpha[_in & (r_beta > +tol)]
-            ) / r_beta[_in & (r_beta > +tol)]
-            l_mat[at_upper & (delta < -tol), 2] = -gamma[at_upper & (delta < -tol)] / delta[at_upper & (delta < -tol)]
-            l_mat[at_lower & (delta > +tol), 3] = -gamma[at_lower & (delta > +tol)] / delta[at_lower & (delta > +tol)]
+            l_mat[_in & (r_beta < -eps), 0] = (
+                self.upper_bounds[_in & (r_beta < -eps)] - r_alpha[_in & (r_beta < -eps)]
+            ) / r_beta[_in & (r_beta < -eps)]
+            l_mat[_in & (r_beta > +eps), 1] = (
+                self.lower_bounds[_in & (r_beta > +eps)] - r_alpha[_in & (r_beta > +eps)]
+            ) / r_beta[_in & (r_beta > +eps)]
+            l_mat[at_upper & (delta < -eps), 2] = -gamma[at_upper & (delta < -eps)] / delta[at_upper & (delta < -eps)]
+            l_mat[at_lower & (delta > +eps), 3] = -gamma[at_lower & (delta > +eps)] / delta[at_lower & (delta > +eps)]
 
             # --- Determine next event ---
-            if np.max(l_mat) < 0:
+            # The current segment w(lam) = r_alpha + lam * r_beta is only valid
+            # for lam at or below the current value: the frontier is traced with
+            # non-increasing lam, so ratios above it are spurious crossings
+            # outside the segment and must not be selected. Ties at the current
+            # lam are kept; degenerate problems resolve them one per iteration.
+            l_mat[l_mat > lam + tol] = -np.inf
+
+            lam_max = np.max(l_mat)
+            if lam_max < 0:
                 break
 
-            secchg, dirchg = np.unravel_index(np.argmax(l_mat), l_mat.shape)
+            # Bland-style anti-cycling rule: on degenerate problems (tied means,
+            # duplicated assets) several events coincide at the same ratio. Among
+            # all events within tol of the best ratio we pick the lowest asset
+            # index (and, within an asset, the lowest event type), so the choice
+            # is deterministic and cannot cycle.
+            tied = np.argwhere(l_mat >= lam_max - tol)
+            secchg, dirchg = tied[0]
             lam = l_mat[secchg, dirchg]
 
             # --- Update free set ---

--- a/src/cvxcla/first.py
+++ b/src/cvxcla/first.py
@@ -58,14 +58,16 @@ def init_algo(
     free = np.full_like(mean, False, dtype=np.bool_)
 
     # Move weights from lower to upper bound
-    # until sum of weights hits or exceeds 1
+    # until sum of weights hits or exceeds 1. The check needs a tolerance:
+    # the increment 1 - sum(weights) can bring the sum to 1 only up to
+    # floating-point error, and without the slack the loop would move on and
+    # mark the NEXT asset (with weight ~0, sitting on its bound) as free
+    # while the genuinely interior asset stays blocked.
     for index in np.argsort(-mean):
         weights[index] += np.min([upper_bounds[index] - lower_bounds[index], 1.0 - np.sum(weights)])
-        if np.sum(weights) >= 1:
+        if np.sum(weights) >= 1 - 1e-12:
             free[index] = True
             break
-
-    # free = _free(weights, lower_bounds, upper_bounds)
 
     if not np.any(free):
         #    # We have not reached the sum of weights of 1...

--- a/src/cvxcla/types.py
+++ b/src/cvxcla/types.py
@@ -67,7 +67,7 @@ class FrontierPoint:
         the portfolio weights sum to 1, which is required for a valid portfolio.
 
         Raises:
-            AssertionError: If the sum of weights is not close to 1.
+            ValueError: If the sum of weights is not close to 1.
 
         """
         # check that the sum is close to 1

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -335,3 +335,98 @@ class TestCLAErrors:
 
         with pytest.raises(ValueError, match="Weights do not sum to 1"):
             cla._append(FakeTP())
+
+
+class TestDegenerateProblems:
+    """Regression tests for degenerate problems (https://github.com/cvxgrp/cvxcla/issues/648).
+
+    Each case below raised ValueError ("Weights below lower bounds") before the
+    event logic learned to (a) classify bounds with the configurable tol,
+    (b) discard spurious event ratios above the current lambda, (c) keep
+    slow bound crossings whose slope falls below the old tol filter, and
+    (d) tolerate float error in the fully-invested check of init_algo.
+    """
+
+    def _assert_valid_frontier(self, cla, upper_bound):
+        """Check lambda monotonicity (within tol) and bounds on all turning points."""
+        lambdas = np.array([tp.lamb for tp in cla.turning_points])
+        assert np.all(np.diff(lambdas) <= cla.tol)
+        weights = np.array([tp.weights for tp in cla.turning_points])
+        assert np.all(weights >= -cla.tol)
+        assert np.all(weights <= upper_bound + cla.tol)
+
+    @pytest.mark.parametrize("n", [20, 50, 100])
+    def test_tied_mean_blocks_with_capped_weights(self, n):
+        """Blocks of identical means with capped upper bounds produce tied events.
+
+        Spurious ratios above the current lambda used to win the argmax and
+        push weights far outside their bounds.
+        """
+        rng = np.random.default_rng(0)
+        _ = rng.standard_normal((10, 10))  # keep historical draw order of the report
+        _ = rng.standard_normal((6, 6))
+        _ = rng.standard_normal(6)
+        l_matrix = rng.standard_normal((n, n))
+        covariance = l_matrix @ l_matrix.T + 0.1 * np.eye(n)
+        mean = np.repeat(rng.standard_normal(n // 5), 5)
+
+        cla = CLA(
+            mean=mean,
+            covariance=covariance,
+            lower_bounds=np.zeros(n),
+            upper_bounds=np.full(n, 0.4),
+            a=np.ones((1, n)),
+            b=np.ones(1),
+        )
+        self._assert_valid_frontier(cla, 0.4)
+
+    def test_slow_bound_crossing_is_not_missed(self):
+        """A free weight with slope just below tol still crosses its bound.
+
+        Over a long lambda range even a slope of ~7e-6 walks a weight out of
+        bounds; the old event filter (|slope| > tol) silently dropped the
+        crossing.
+        """
+        rng = np.random.default_rng(63)
+        n = int(rng.integers(3, 40))
+        l_matrix = rng.standard_normal((n, n))
+        covariance = l_matrix @ l_matrix.T + 0.05 * np.eye(n)
+        mean = rng.standard_normal(n)
+        upper = np.full(n, float(rng.uniform(2.0 / n, 1.0)))
+
+        cla = CLA(
+            mean=mean,
+            covariance=covariance,
+            lower_bounds=np.zeros(n),
+            upper_bounds=upper,
+            a=np.ones((1, n)),
+            b=np.ones(1),
+        )
+        self._assert_valid_frontier(cla, upper[0])
+
+    def test_first_turning_point_full_within_float_error(self):
+        """The fully-invested check of init_algo needs a float tolerance.
+
+        When the partial fill brings the sum to 1 only up to float error, the
+        next asset (weight ~0, on its bound) used to be marked free while the
+        interior asset stayed blocked, breaking the first segment.
+        """
+        rng = np.random.default_rng(411)
+        n = int(rng.integers(3, 40))
+        l_matrix = rng.standard_normal((n, n))
+        covariance = l_matrix @ l_matrix.T + 0.05 * np.eye(n)
+        mean = rng.standard_normal(n)
+        upper = np.full(n, float(rng.uniform(2.0 / n, 1.0)))
+
+        cla = CLA(
+            mean=mean,
+            covariance=covariance,
+            lower_bounds=np.zeros(n),
+            upper_bounds=upper,
+            a=np.ones((1, n)),
+            b=np.ones(1),
+        )
+        # the first turning point must have its free asset strictly inside the bounds
+        first = cla.turning_points[0]
+        assert first.weights[first.free].item() > cla.tol
+        self._assert_valid_frontier(cla, upper[0])

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -430,3 +430,33 @@ class TestDegenerateProblems:
         first = cla.turning_points[0]
         assert first.weights[first.free].item() > cla.tol
         self._assert_valid_frontier(cla, upper[0])
+
+
+class TestAppendTolerance:
+    """Tests for the tol argument of _append (https://github.com/cvxgrp/cvxcla/issues/651)."""
+
+    @pytest.fixture
+    def cla(self):
+        """A solved 3-asset problem to call _append on."""
+        return CLA(
+            mean=np.array([0.1, 0.15, 0.2]),
+            covariance=np.eye(3) * 0.04,
+            lower_bounds=np.zeros(3),
+            upper_bounds=np.ones(3),
+            a=np.ones((1, 3)),
+            b=np.ones(1),
+        )
+
+    def test_explicit_zero_tol_is_honored(self, cla):
+        """tol=0 must validate exactly instead of falling back to self.tol."""
+        # violates the lower bound by less than self.tol but more than 0
+        tp = TurningPoint(weights=np.array([-1e-7, 0.5, 0.5 + 1e-7]), free=np.array([True, False, False]))
+        with pytest.raises(ValueError, match="Weights below lower bounds"):
+            cla._append(tp, tol=0)
+
+    def test_default_tol_accepts_tiny_violation(self, cla):
+        """The same point passes under the default tolerance."""
+        tp = TurningPoint(weights=np.array([-1e-7, 0.5, 0.5 + 1e-7]), free=np.array([True, False, False]))
+        before = len(cla)
+        cla._append(tp)
+        assert len(cla) == before + 1

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,125 @@
+"""Property-based tests for the Critical Line Algorithm.
+
+Hypothesis generates random portfolio problems - including deliberately
+degenerate ones with tied means, duplicated assets, and capped weights - and
+checks invariants that must hold on every efficient frontier
+(https://github.com/cvxgrp/cvxcla/issues/649):
+
+- weights respect the bounds and sum to 1 at every turning point
+- lambda is non-increasing along the frontier (within tol)
+- expected return is non-increasing along the turning points
+- the dense and FactorCovariance backends agree on the same problem
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cvxcla import CLA, FactorCovariance
+
+
+def _spd_matrix(rng: np.random.Generator, n: int) -> np.ndarray:
+    """Build a random symmetric positive definite covariance matrix."""
+    l_matrix = rng.standard_normal((n, n))
+    return l_matrix @ l_matrix.T + 0.05 * np.eye(n)
+
+
+@st.composite
+def problems(draw: st.DrawFn) -> dict:
+    """Generate a random long-only fully-invested portfolio problem.
+
+    The mean vector is drawn from one of three styles: generic random values,
+    blocks of identical values (tied means), and values rounded to one decimal
+    (many near-ties). Upper bounds are uniform and can be tight enough that
+    several assets must sit at the cap.
+    """
+    seed = draw(st.integers(min_value=0, max_value=2**32 - 1))
+    n = draw(st.integers(min_value=2, max_value=25))
+    style = draw(st.sampled_from(["generic", "tied-blocks", "rounded"]))
+    tight = draw(st.booleans())
+
+    rng = np.random.default_rng(seed)
+    covariance = _spd_matrix(rng, n)
+
+    if style == "generic":
+        mean = rng.standard_normal(n)
+    elif style == "tied-blocks":
+        block = max(1, n // 4)
+        mean = np.resize(np.repeat(rng.standard_normal(block), 4), n)
+    else:
+        mean = np.round(rng.standard_normal(n), 1)
+
+    upper = np.full(n, float(rng.uniform(2.0 / n, 1.0))) if tight and n >= 3 else np.ones(n)
+
+    return {
+        "mean": mean,
+        "covariance": covariance,
+        "lower_bounds": np.zeros(n),
+        "upper_bounds": upper,
+        "a": np.ones((1, n)),
+        "b": np.ones(1),
+    }
+
+
+@pytest.mark.property
+class TestFrontierInvariants:
+    """Invariants that every computed frontier must satisfy."""
+
+    @given(problem=problems())
+    @settings(max_examples=80, deadline=None)
+    def test_turning_points_are_valid(self, problem):
+        """Weights stay within bounds and sum to 1; lambda never increases beyond tol."""
+        cla = CLA(**problem)
+        tol = cla.tol
+
+        weights = np.array([tp.weights for tp in cla.turning_points])
+        assert np.all(weights >= problem["lower_bounds"] - tol)
+        assert np.all(weights <= problem["upper_bounds"] + tol)
+        np.testing.assert_allclose(weights.sum(axis=1), 1.0, atol=1e-6)
+
+        lambdas = np.array([tp.lamb for tp in cla.turning_points])
+        assert np.all(np.diff(lambdas) <= tol)
+
+    @given(problem=problems())
+    @settings(max_examples=80, deadline=None)
+    def test_expected_return_is_non_increasing(self, problem):
+        """The frontier is traced from the max-return portfolio downwards."""
+        cla = CLA(**problem)
+        returns = cla.frontier.returns
+        assert np.all(np.diff(returns) <= 1e-6)
+
+
+@pytest.mark.property
+class TestBackendAgreement:
+    """The dense and factor backends must produce the same frontier."""
+
+    @given(
+        seed=st.integers(min_value=0, max_value=2**32 - 1),
+        n=st.integers(min_value=2, max_value=20),
+        k=st.integers(min_value=1, max_value=5),
+    )
+    @settings(max_examples=40, deadline=None)
+    def test_factor_matches_dense(self, seed, n, k):
+        """A factor model solved via Woodbury matches its dense materialisation."""
+        rng = np.random.default_rng(seed)
+        d = rng.uniform(0.1, 1.0, n)
+        u = rng.standard_normal((n, k))
+        delta = rng.uniform(0.5, 2.0, k)
+
+        factor = FactorCovariance(d=d, u=u, delta=delta)
+        dense = np.diag(d) + u @ np.diag(delta) @ u.T
+
+        problem = {
+            "mean": rng.standard_normal(n),
+            "lower_bounds": np.zeros(n),
+            "upper_bounds": np.ones(n),
+            "a": np.ones((1, n)),
+            "b": np.ones(1),
+        }
+        cla_factor = CLA(covariance=factor, **problem)
+        cla_dense = CLA(covariance=dense, **problem)
+
+        assert len(cla_factor) == len(cla_dense)
+        for tp_f, tp_d in zip(cla_factor.turning_points, cla_dense.turning_points, strict=True):
+            np.testing.assert_allclose(tp_f.weights, tp_d.weights, atol=1e-6)

--- a/uv.lock
+++ b/uv.lock
@@ -150,6 +150,7 @@ dev = [
     { name = "pandas" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -171,6 +172,7 @@ dev = [
 ]
 lint = []
 test = [
+    { name = "hypothesis", specifier = ">=6.100" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-timeout", specifier = ">=2.3" },
 ]
@@ -191,6 +193,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.155.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/04/64032a1dccd2233615c8a3f701bbb563558575ed017496a24b6d81762c91/hypothesis-6.155.2.tar.gz", hash = "sha256:ae36880287c9c5defe9f199d3d2b67d9947a4da2a46e6c57373cbdf2345b20e1", size = 477765, upload-time = "2026-06-05T16:32:23.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6e/e735f27ac1a530a4cd0a31cd970ec495a3a11830fdc5d281cc292593b330/hypothesis-6.155.2-py3-none-any.whl", hash = "sha256:c85ce6dcd630a90ce501f1d1dd1bc84b97f5649ca8a27e134c8cbf5aa480b1a5", size = 544213, upload-time = "2026-06-05T16:32:21.15Z" },
 ]
 
 [[package]]
@@ -1017,6 +1031,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -151,6 +151,7 @@ dev = [
 ]
 test = [
     { name = "pytest" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -169,7 +170,10 @@ dev = [
     { name = "pandas", specifier = "==3.0.3" },
 ]
 lint = []
-test = [{ name = "pytest", specifier = ">=7.0" }]
+test = [
+    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
+]
 
 [[package]]
 name = "docutils"
@@ -794,6 +798,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Addresses all five issues from the quality review, one commit per issue.

Closes #648
Closes #649
Closes #650
Closes #651
Closes #652

## #648 — Robust event logic on degenerate problems (fixed, not just xfail'd)

Tracing tie-heavy failures revealed four distinct mechanisms, all fixed:

1. **Bound classification** now uses the configurable `self.tol` instead of `np.isclose` defaults.
2. **Spurious events above the current λ are discarded.** The segment `w(λ) = α + λβ` is only valid for non-increasing λ; ratios above the current λ are crossings outside the segment. On tie-heavy problems these used to win the argmax (observed: λ jumping from 7.06 to 77.5) and push weights far out of bounds.
3. **Near-tied events resolve deterministically** (lowest asset index, then lowest event type — Bland-style), so degenerate ties cannot cycle.
4. **The event slope filter dropped from `tol` to `sqrt(eps)`.** A free weight moving at slope ~7e-6 (just under the old `tol = 1e-5` filter) still crosses its bound over a long λ range; the old filter silently dropped that event and the weight drifted out of bounds. Noise-level slopes stay excluded, and the λ-window from (2) removes the huge ratios in between.
5. **`init_algo` tolerates float error in the fully-invested check.** When the partial fill reaches 1 only up to rounding (`sum = 0.9999999999999999`), the next asset (weight ≈ 0, on its bound) used to be marked free while the genuinely interior asset stayed blocked, breaking the first segment.

A 1000-seed random stress sweep (tied mean blocks, rounded means, capped weights, n up to 40) went from widespread `ValueError: Weights below lower bounds` failures to passing throughout. Deterministic regression tests cover each mechanism.

## #649 — Property-based tests (Hypothesis)

`tests/test_properties.py` generates random long-only problems — including deliberately degenerate styles (tied mean blocks, rounded means, tight caps) — and asserts frontier invariants: bounds and budget at every turning point, λ non-increasing within tol, expected return non-increasing, and dense vs `FactorCovariance` agreement turning point by turning point. Verified the suite falsifies the pre-#648 event logic within a handful of examples.

## #650 — README drift

License badge corrected to Apache 2.0, stale `_solve`/line-number anchors replaced, leftover scaffolding comments removed (`# add Philipp` in pyproject, commented-out `_free` call in first.py).

## #651 — `_append` tolerance semantics

`tol = tol or self.tol` silently ignored an explicit `tol=0`; now `tol = self.tol if tol is None else tol`, with tests for both the exact and default paths. Docstrings corrected from `AssertionError` to `ValueError`.

## #652 — DX

`uv run pytest` works on a fresh clone (test group added to uv default groups), and `pytest-timeout` is installed so the `timeout = 60` already configured in pytest.ini takes effect instead of warning.

## Test results

- Full suite: **110 passed, 2 skipped** (plotly not installed), no warnings, ~1.5s.
- Property suite alone: 200 examples across 3 properties.
- 1000-seed stress sweep: 1000/1000 valid frontiers (the single earlier flag was a λ "increase" of 6.8e-6, below the algorithm's documented tie tolerance of 1e-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)