### PR TITLE
CI: fix invalid rhiza_scorecard workflow (permissions mismatch)

### DIFF
--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,13 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.1
+    # TEMPORARY: v0.19.1's reusable workflow declares top-level
+    # `permissions: read-all`, which this least-privilege caller cannot satisfy,
+    # so GitHub rejects the run ("is requesting '... read', but is only allowed
+    # '... none'"). Pin to the commit that narrows the reusable workflow's
+    # top-level permissions to match the job (jebel-quant/rhiza#1251) until a
+    # release including it lands; the next template sync will re-pin to a tag.
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@fd75f09f8f7b37f4d8d1b79d55c0122b92fe53af  # main / #1251
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning


### PR DESCRIPTION
## Problem
The Scorecard workflow is invalid:

```
Invalid workflow file: .github/workflows/rhiza_scorecard.yml#L38
Error calling workflow 'jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.1'.
The workflow is requesting 'artifact-metadata: read, ... statuses: read',
but is only allowed 'artifact-metadata: none, ...'.
```

The reusable `rhiza_scorecard.yml@v0.19.1` declares top-level
`permissions: read-all`, but this caller stub grants a narrow least-privilege set
(`security-events: write`, `id-token: write`, `contents: read`, `actions: read`),
so GitHub rejects the call.

## Fix (temporary)
Upstream fix: **jebel-quant/rhiza#1251** narrows the reusable workflow's top-level
permissions to match its job (no runtime change). Until a rhiza release including
it lands, pin the `uses:` ref to that commit (`fd75f09`). The next template sync
will re-pin this back to a version tag.

## Validation
- `yaml.safe_load` + `actionlint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)