### PR TITLE
docs: compile Notebooks and Reports (follow jquantstats standard)

### DIFF
--- a/.rhiza/.env
+++ b/.rhiza/.env
@@ -8,6 +8,6 @@
 # Add or uncomment only the variables you want to override.
 # Variables defined here are exported to all Make recipes.
 
-MARIMO_FOLDER=docs/notebooks
+MARIMO_FOLDER=book/marimo/notebooks
 SOURCE_FOLDER=src
 RHIZA_CI_OS_MATRIX=["ubuntu-latest","macos-latest","windows-latest"]

--- a/docs/factor.md
+++ b/docs/factor.md
@@ -56,7 +56,7 @@ replacing the rest by their average $\bar{d}$ gives
 $$\Sigma_{\text{clean}} = \bar{d}\, I + V_k (\Lambda_k - \bar{d} I) V_k^\top,$$
 
 i.e. `FactorCovariance(d=np.full(n, d_bar), u=v_k, delta=lambda_k - d_bar)`.
-See the [factor notebook](notebooks.md) for an end-to-end example: simulated
+See the [factor notebook](notebooks/factor.html) for an end-to-end example: simulated
 returns → Marchenko–Pastur threshold → factors → exact frontier.
 
 ## Benchmark
@@ -66,7 +66,7 @@ $k = n/20$, budget constraint, run with `experiments/factor_benchmark.py`
 (Apple Silicon, single seed; the dense column wraps the same problem in a
 plain `numpy` matrix):
 
-| n | k | turning points | dense [s] | factor [s] | speedup |
+| n | k | turning points | dense (s) | factor (s) | speedup |
 |---:|---:|---:|---:|---:|---:|
 | 500 | 25 | 505 | 0.42 | 0.08 | 5x |
 | 2000 | 100 | 2051 | 31.90 | 1.34 | 24x |

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -1,3 +1,0 @@
-# Notebooks
-
-Run `make book` to build the interactive Marimo notebooks.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,5 +15,9 @@ theme:
 nav:
   - Home: index.md
   - Factor backend: factor.md
-  - Notebooks: notebooks.md
-  - Reports: reports.md
+  - Notebooks:
+    - CLA: notebooks/cla.html
+    - Factor: notebooks/factor.html
+  - Reports:
+    - Test Report: reports/html-report/report.html
+    - Coverage Report: reports/html-coverage/index.html


### PR DESCRIPTION
## Problem
The **Notebooks** and **Reports** docs pages were no longer compiled:
- `.rhiza/.env` set `MARIMO_FOLDER=docs/notebooks` (empty), while the Marimo
  notebook sources actually live in `book/marimo/notebooks/` — so `make book`'s
  export step found nothing and skipped them.
- the mkdocs nav pointed at `notebooks.md` / `reports.md` *stub* pages, and
  `reports.md` never existed.

## Fix — follow the `jebel-quant/jquantstats` standard
- **`.rhiza/.env`**: `MARIMO_FOLDER=book/marimo/notebooks` (matches jquantstats
  and where the sources already are), so `make book` exports
  `book/marimo/notebooks/*.py` → `docs/notebooks/*.html`.
- **`mkdocs.yml`**: replace the `.md` stubs with `Notebooks` / `Reports` nav
  sections linking directly to the generated HTML:
  ```yaml
  - Notebooks:
    - CLA: notebooks/cla.html
    - Factor: notebooks/factor.html
  - Reports:
    - Test Report: reports/html-report/report.html
    - Coverage Report: reports/html-coverage/index.html
  ```
- Remove the `docs/notebooks.md` stub; repoint `factor.md`'s link to
  `notebooks/factor.html`. (`.gitignore` already excludes the generated
  `docs/notebooks/*.html`, `docs/reports/`, `_book/`.)
- Also tidied a pre-existing `factor.md` table header (`dense [s]` → `dense (s)`)
  that mkdocs misparsed as a link reference.

## Verification
`make book` now builds with **No issues found**; both notebooks (CLA, Factor)
and both reports (test, coverage) render in the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)