### PR TITLE
fix(cla): diagnose covariance degeneracy with an actionable error + remedy

### DIFF
--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -237,10 +237,10 @@ class CLA:
 
             # --- Compute new turning point ---
             new_weights = r_alpha + lam * r_beta
-            self._append(TurningPoint(lamb=lam, weights=new_weights, free=free))
+            self._emit(lam, new_weights, free)
 
         # Final point at lambda = 0
-        self._append(TurningPoint(lamb=0, weights=r_alpha, free=last.free))
+        self._emit(0.0, r_alpha, last.free)
 
     def __len__(self) -> int:
         """Get the number of turning points in the efficient frontier.
@@ -296,6 +296,40 @@ class CLA:
             raise ValueError(msg)
 
         self.turning_points.append(tp)
+
+    def _emit(self, lamb: float, weights: NDArray[np.float64], free: NDArray[np.bool_]) -> None:
+        """Build and store a turning point, diagnosing covariance degeneracy.
+
+        The turning-point loop assumes a strictly convex objective, i.e. a
+        positive-definite covariance. When the covariance is rank-deficient (for
+        example a sample covariance estimated from fewer days than assets), the
+        trace eventually frees more assets than the covariance has rank; the
+        free-asset block ``Sigma_FF`` is then (near-)singular and the reduced KKT
+        solve returns an infeasible point — a weight outside its bounds or a
+        budget that no longer sums to one. Rather than surface the resulting
+        low-level constraint error, raise an actionable diagnosis that names the
+        cause and the remedy. Well-posed (positive-definite) problems never reach
+        this branch, so their behaviour is unchanged.
+
+        Raises:
+            ValueError: With a degeneracy-specific message when the turning point
+                is infeasible; otherwise propagates nothing.
+        """
+        try:
+            self._append(TurningPoint(lamb=lamb, weights=weights, free=free))
+        except ValueError as exc:
+            n_free = int(np.count_nonzero(free))
+            msg = (
+                f"Critical Line Algorithm hit a degeneracy at lambda={lamb:.4g} "
+                f"(free-set size {n_free}): the free-asset covariance block is "
+                "(near-)singular, so the reduced KKT system has no unique, "
+                "feasible solution. The algorithm requires a positive-definite "
+                "covariance. Remedies: apply covariance shrinkage (e.g. "
+                "Ledoit-Wolf) so the covariance is full rank, or use a "
+                "FactorCovariance backend (diagonal-plus-low-rank with a positive "
+                "idiosyncratic floor), which is positive definite by construction."
+            )
+            raise ValueError(msg) from exc
 
     @property
     def frontier(self) -> Frontier:

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
-from cvxcla import CLA
+from cvxcla import CLA, FactorCovariance
 from cvxcla.types import TurningPoint
 
 
@@ -223,6 +223,56 @@ class TestCLAEdgeCases:
             assert np.isclose(np.sum(tp.weights), 1.0)
             assert np.all(tp.weights >= -cla.tol)
             assert np.all(tp.weights <= 1.0 + cla.tol)
+
+    def test_rank_deficient_covariance_raises_degeneracy(self):
+        """A rank-deficient covariance yields a clear degeneracy diagnosis.
+
+        Estimating a covariance from fewer factors/observations than assets makes
+        it singular; the trace then frees more assets than its rank and the
+        free-asset block becomes singular. The algorithm must report this as a
+        degeneracy (naming the remedy) rather than emit an infeasible point.
+        """
+        rng = np.random.default_rng(2)
+        factors = rng.standard_normal((20, 8))
+        covariance = factors @ factors.T  # rank 8 < 20 assets
+        n = 20
+        with pytest.raises(ValueError, match="degeneracy"):
+            CLA(
+                mean=rng.uniform(0.0, 1.0, n),
+                covariance=covariance,
+                lower_bounds=np.zeros(n),
+                upper_bounds=np.ones(n),
+                a=np.ones((1, n)),
+                b=np.ones(1),
+            )
+
+    def test_factor_covariance_resolves_degeneracy(self):
+        """The FactorCovariance backend is PD by construction and traces cleanly.
+
+        The same low-rank risk structure that breaks the dense backend is handled
+        when wrapped as a FactorCovariance with a positive idiosyncratic floor --
+        the documented remedy for the degeneracy above.
+        """
+        rng = np.random.default_rng(2)
+        n, k = 20, 8
+        factors = rng.standard_normal((n, k))
+        cov = factors @ factors.T
+        evals, evecs = np.linalg.eigh(cov)
+        top = np.argsort(evals)[::-1][:k]
+        backend = FactorCovariance(
+            d=np.full(n, 0.5 * np.trace(cov) / n),
+            u=evecs[:, top],
+            delta=np.clip(evals[top], 1e-8, None),
+        )
+        cla = CLA(
+            mean=rng.uniform(0.0, 1.0, n),
+            covariance=backend,
+            lower_bounds=np.zeros(n),
+            upper_bounds=np.ones(n),
+            a=np.ones((1, n)),
+            b=np.ones(1),
+        )
+        assert len(cla) >= 2
 
     def test_equal_returns(self):
         """Test with assets having equal expected returns."""


### PR DESCRIPTION
Addresses the degeneracy limitation the paper documents — turns a cryptic deep
failure into a precise, actionable diagnosis.

## Diagnosis (precise)
On a **rank-deficient covariance** (e.g. a sample covariance estimated from fewer
days than assets — the paper's short-window S&P 500 case), the turning-point
trace eventually frees **more assets than the covariance has rank**. The
free-asset block `Σ_FF` is then (near-)singular, and the reduced KKT solve
returns an **infeasible point** — a weight outside its bounds, or a budget that
no longer sums to one (instrumented: at `n_free = rank+2`, a weight lands at
≈ −0.028). Previously this surfaced as a cryptic `Weights below lower bounds` /
`Weights do not sum to 1` deep in the loop.

A rank-deficient covariance is **genuinely ill-posed** (the QP Hessian is singular
→ no unique optimum), so no solver recovers valid weights without changing the
problem. A tiny ridge does not help; only materially changing the covariance
(strong shrinkage) or using a PD structure does.

## Fix
Route turning-point emission through a new `_emit()` that detects the infeasible
point and raises a clear error naming **the cause** (singular free block, λ,
free-set size) and **the remedy**:
- covariance **shrinkage** (e.g. Ledoit–Wolf) so Σ is full rank, or
- the **`FactorCovariance`** backend (diagonal-plus-low-rank with a positive
  idiosyncratic floor) — **positive definite by construction**, and it traces the
  same low-rank structure cleanly.

Well-posed positive-definite problems never reach this branch — behaviour and the
exact frontier are **unchanged** (verified by the existing suite + the exactness
check).

## Tests
- `test_rank_deficient_covariance_raises_degeneracy` — the diagnosis fires.
- `test_factor_covariance_resolves_degeneracy` — the documented remedy traces.
- Full suite green, **100% coverage**, 135 tests; `fmt`/`typecheck`/`deptry`/
  `security`/`docs-coverage` all pass.

## Scope / honesty
This makes the failure **safe and self-explanatory**; it does not make an
ill-posed (rank-deficient) problem solvable — that is mathematically impossible
without regularising. The principled resolution is a PD covariance, which the
`FactorCovariance` backend provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)