### PR TITLE
Chore: sync Rhiza template v0.19.1 → v0.19.3

### DIFF
--- a/.claude/commands/rhiza_book.md
+++ b/.claude/commands/rhiza_book.md
@@ -49,5 +49,5 @@ Do the following, in order:
    a generated, gitignored artifact.
 
 If `$ARGUMENTS` is non-empty, treat it as an override hint — e.g. a custom port
-(`/book 9000`) or a request to only build without serving/opening (`/book
+(`/rhiza_book 9000`) or a request to only build without serving/opening (`/rhiza_book
 build-only`) — and adjust accordingly.

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.3
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.3
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.3
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -7,6 +7,11 @@
 #          parsing utilities. Pull requests run short code-change fuzzing,
 #          while main-branch pushes and the weekly schedule run batch fuzzing.
 #
+#          Opt-in: fuzzing is OFF by default and very optional. Set the
+#          repository variable `FUZZING_ENABLED` to 'true' to run it (a
+#          .clusterfuzzlite/ config must also be present); otherwise the
+#          reusable workflow skips fuzzing (the run stays green).
+#
 #          Thin stub: the fuzzing logic lives in the reusable workflow in
 #          jebel-quant/rhiza; this file only wires up the triggers.
 #
@@ -29,12 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    # TEMPORARY: v0.19.1's reusable workflow runs build_fuzzers unconditionally and
-    # fails with "lstat .clusterfuzzlite: no such file or directory" in repos (like
-    # this one) that ship no .clusterfuzzlite/ config. Pin to the commit that adds
-    # the skip-guard + FUZZING_ENABLED opt-in (jebel-quant/rhiza#1246) until a
-    # release including it lands; the next template sync will re-pin this to a tag.
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@6fcf7843f14ed0ebc6fd0a0dec64878827609a68  # main / #1246
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.3
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_paper.yml
+++ b/.github/workflows/rhiza_paper.yml
@@ -3,10 +3,10 @@
 #
 # Workflow: Paper
 #
-# Purpose: Compile the LaTeX paper (paper/*.tex) to a PDF and publish it
+# Purpose: Compile the LaTeX paper (docs/paper/*.tex) to a PDF and publish it
 #          as a downloadable workflow artifact. Pushes the PDF to a paper branch.
 #
-# Trigger: On push/PR to main/master when paper/** changes, or manual dispatch.
+# Trigger: On push/PR to main/master when docs/paper/** changes, or manual dispatch.
 
 name: "(RHIZA) PAPER"
 
@@ -17,18 +17,18 @@ on:
   push:
     branches: [ main, master ]
     paths:
-      - 'paper/**'
+      - 'docs/paper/**'
       - '.github/workflows/rhiza_paper.yml'
   pull_request:
     branches: [ main, master ]
     paths:
-      - 'paper/**'
+      - 'docs/paper/**'
       - '.github/workflows/rhiza_paper.yml'
   workflow_dispatch:
 
 jobs:
   paper:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_paper.yml@v0.19.3
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.1
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.3
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,13 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    # TEMPORARY: v0.19.1's reusable workflow declares top-level
-    # `permissions: read-all`, which this least-privilege caller cannot satisfy,
-    # so GitHub rejects the run ("is requesting '... read', but is only allowed
-    # '... none'"). Pin to the commit that narrows the reusable workflow's
-    # top-level permissions to match the job (jebel-quant/rhiza#1251) until a
-    # release including it lands; the next template sync will re-pin to a tag.
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@fd75f09f8f7b37f4d8d1b79d55c0122b92fe53af  # main / #1251
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.3
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.3
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.1
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.3
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: a1ed3dfa30b461413bfee24a784cff718f7b944f
+sha: 99827da43cc32c135388641897fede359dfce4a4
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.1
+ref: v0.19.3
 include: []
 exclude: []
 templates:
@@ -9,8 +9,9 @@ templates:
 - github-paper
 files:
 - .bandit
-- .claude/commands/book.md
-- .claude/commands/rhiza.md
+- .claude/commands/rhiza_book.md
+- .claude/commands/rhiza_quality.md
+- .claude/commands/rhiza_update.md
 - .editorconfig
 - .github/CONFIG.md
 - .github/DISCUSSION_TEMPLATE/help-wanted.yml
@@ -104,5 +105,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-15T19:21:41Z'
+synced_at: '2026-06-16T14:10:01Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.19.1"
+ref: "v0.19.3"
 
 profiles:
   - github-project


### PR DESCRIPTION
Bumps the pinned Rhiza template from **v0.19.1** to **v0.19.3** (latest), applies the sync, and relocates the LaTeX paper to match the template's expected layout.

## What's between the versions
- **v0.19.2** — point GitHub paper workflow at `docs/paper` matching `paper.mk`/GitLab (#1249); scope fuzzing `security-events: write` to the job level (#1250); match scorecard reusable-workflow top-level permissions to its job (#1251); recompile gh-aw lock files (#1254); skip fuzzing when no `.clusterfuzzlite/` config (#1246); rename Claude commands to `rhiza_*`.
- **v0.19.3** — keep scorecard `id-token`/`security-events: write` at job level only (#1255).

## Conflict resolution
All conflicts were in Rhiza-managed `.github/workflows/*` stubs.

- **`rhiza_scorecard.yml`** / **`rhiza_fuzzing.yml`** — these stubs carried local **TEMPORARY** commit-SHA pins that worked around v0.19.1 reusable-workflow bugs (#1251 scorecard top-level permissions, #1246 fuzzing run with no `.clusterfuzzlite/`). v0.19.3 ships those fixes, so the workarounds were dropped and the stubs re-pinned to `@v0.19.3` — exactly what the rejected hunks intended ("the next template sync will re-pin to a tag"). Verified the upstream v0.19.3 reusable workflows contain the fixes (scorecard uses least-privilege top-level perms with writes scoped to the job; fuzzing has the `.clusterfuzzlite/` detect-and-skip guard + `FUZZING_ENABLED` gate).
- **`rhiza_mutation.yml`** — local `MUTATION_ENABLED` opt-in gate already matched upstream; only the reusable-workflow ref was bumped to `@v0.19.3`.
- **Remaining stubs** (benchmark, book, ci, codeql, marimo, paper, release, sync, weekly) — clean upstream ref bumps. `rhiza_paper.yml` also moved its trigger path `paper/** → docs/paper/**` (#1249).
- **`.claude/commands/book.md` → `rhiza_book.md`** — upstream command rename.

Finished with **zero** `*.rej` files and **zero** conflict markers; all touched workflow YAML validated (pre-commit `Validate GitHub Workflows` + actionlint passed).

## Paper relocation `paper/` → `docs/paper/`
The #1249 fix aligned the paper workflow trigger and `paper.mk` (`PAPER_DIR ?= docs/paper`) on `docs/paper`, but this repo kept its LaTeX source at `paper/`, so the paper CI would no longer fire on changes. Resolved by moving the paper into `docs/paper/`:
- `git mv paper docs/paper` (cla.tex + 4 figure PDFs).
- Updated the figure-output paths in `experiments/{frontier_20x50,frontier_real,rank_scaling,runtime_scaling}.py` to `docs/paper/*.pdf`.
- The bare-filename `\includegraphics{...}` in `cla.tex` are relative to the `.tex` and needed no change.
- Verified with `make paper` → compiles `docs/paper/cla.pdf` (16 pages); build artifacts cleaned with `make paper-clean`.

## Gate results (all green)
| Gate | Result |
|------|--------|
| `make fmt` | ✅ PASS |
| `make typecheck` | ✅ PASS (ty + mypy strict) |
| `make docs-coverage` | ✅ PASS (100%) |
| `make deptry` | ✅ PASS |
| `make security` | ✅ PASS (pip-audit + bandit) |
| `make test` | ✅ PASS (144 passed, 99% cov) |
| `make paper` | ✅ PASS (compiles docs/paper/cla.pdf) |

No upstream Rhiza fixes are required — nothing is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)