### PR TITLE
docs: link compiled paper PDF in book nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ theme:
 nav:
   - Home: index.md
   - Factor backend: factor.md
+  - Paper: https://github.com/cvxgrp/cvxcla/blob/paper/cla.pdf
   - Notebooks:
     - CLA: notebooks/cla.html
     - Factor: notebooks/factor.html


### PR DESCRIPTION
## Summary
Adds a top-level **Paper** entry to the MkDocs nav linking to the compiled paper PDF.

The book build (`make book` → zensical) does not compile the LaTeX — that's handled by the separate `rhiza_paper.yml` workflow, which compiles `docs/paper/cla.tex` and publishes `cla.pdf` to the root of the `paper` branch. The nav now points at the GitHub-rendered PDF there:

```yaml
- Paper: https://github.com/cvxgrp/cvxcla/blob/paper/cla.pdf
```

## Notes
- Verified the `paper` branch exists on origin and holds `cla.pdf`.
- The link renders in GitHub's built-in PDF viewer (with a download button). For a raw download instead, swap to `https://raw.githubusercontent.com/cvxgrp/cvxcla/paper/cla.pdf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)