### PR TITLE
docs(paper): note the 2.7 max Sharpe is measured in-sample

### DIFF
--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -848,7 +848,10 @@ rank-$20$ diagonal-plus-low-rank approximation of the same covariance traces a
 near-identical frontier ($89$ turning points) in $\approx 9$~ms through the
 Woodbury backend. The annualised frontier spans expected returns of
 $0.14$--$0.89$ over volatilities of $0.10$--$0.87$, with a maximum Sharpe ratio of
-about $2.7$.
+about $2.7$. This figure is measured in-sample --- the frontier is optimised over
+the same sample mean and covariance from which it is computed --- and so overstates
+what is achievable out-of-sample; it is reported only to characterise the geometry
+of the frontier on a realistic problem, not as a claim of attainable performance.
 
 \begin{figure}[h]
 \centering


### PR DESCRIPTION
## Summary
Adds an in-sample caveat to the S&P 500 example in `docs/paper/cla.tex`.

The reported ~2.7 maximum Sharpe ratio is optimised over the **same** sample mean and covariance from which the frontier is computed, so it is biased upward and does not reflect out-of-sample performance. The new sentence makes this explicit so the figure is read as characterising frontier geometry on a realistic problem, not as a claim of attainable performance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)