### PR TITLE
docs: fix coverage badge link to published report path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/cvxcla)](https://pypi.org/project/cvxcla/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/cvxcla?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/cvxcla)
-[![Coverage](https://www.cvxgrp.org/cvxcla/coverage-badge.svg)](https://www.cvxgrp.org/cvxcla/tests/html-coverage/index.html)
+[![Coverage](https://www.cvxgrp.org/cvxcla/coverage-badge.svg)](https://www.cvxgrp.org/cvxcla/reports/html-coverage/index.html)
 
 ---
 


### PR DESCRIPTION
## Summary
The README coverage badge linked to `https://www.cvxgrp.org/cvxcla/tests/html-coverage/index.html`, which **404s** on the published site. The book build copies reports into `docs/reports/`, so the live coverage report is at `reports/html-coverage/index.html` (verified 200). This points the badge at the correct path.

The badge **image** (`coverage-badge.svg`) is unchanged — it's auto-generated from `coverage.xml` at book-build time and already reflects current coverage (100%).

## Verification
- `tests/html-coverage/index.html` → 404 (old target)
- `reports/html-coverage/index.html` → 200 (new target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)