### PR TITLE
Extract a generic parametric active-set path tracer (CLA + LASSO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # 📈 [cvxcla](https://www.cvxgrp.org/cvxcla) - Critical Line Algorithm for Portfolio Optimization
 
 [![PyPI version](https://img.shields.io/pypi/v/cvxcla)](https://pypi.org/project/cvxcla/)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/cvxcla?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/cvxcla)
 [![Coverage](https://www.cvxgrp.org/cvxcla/coverage-badge.svg)](https://www.cvxgrp.org/cvxcla/reports/html-coverage/index.html)
 
@@ -277,7 +277,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE)
+This project is licensed under the MIT License - see the [LICENSE](LICENSE)
 file for details.
 
 ## 🔍 Related Projects

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -107,9 +107,11 @@ free-to-blocked cross product. Capturing exactly this contract as a small
 protocol decouples the algorithm from the covariance representation, so a
 structured risk model (e.g.\ a diagonal-plus-low-rank factor covariance solved
 through the Woodbury identity) drops in as a backend and traces the
-\emph{same exact frontier} at a fraction of the cost, without a single change to
-the turning-point loop. This is the paper's main engineering contribution; the
-experiments of \S\ref{sec:experiment} quantify the resulting speed-up.
+\emph{same exact frontier} at lower memory in every case, and at a fraction of the
+time when its rank is genuinely low (few factors over many assets), without a
+single change to the turning-point loop. This is the paper's main engineering
+contribution; the experiments of \S\ref{sec:experiment} quantify both the memory
+saving and the regime-dependent speed-up.
 
 \paragraph{Contributions.}
 This is a \emph{systems} contribution: we claim no new turning points (the
@@ -699,7 +701,12 @@ NumPy~2.4.6 linked against the Apple Accelerate BLAS, and PyPortfolioOpt~1.6.0.
 Absolute times are therefore machine-specific and BLAS-dependent; the empirical
 scaling exponents and the relative speedups between implementations, which are
 the quantities we draw conclusions from, are far more portable than the raw
-milliseconds.
+milliseconds. Each reported timing is the median of three repetitions on identical
+inputs (the bands in the figures span their range). Beyond the one-off experiment
+scripts cited above, the relative backend performance is tracked continuously by a
+committed \texttt{pytest-benchmark} suite
+(\srcfile{tests/benchmarks/test_backend_scaling.py}{tests/benchmarks/}) run in CI,
+so the comparisons here are reproducible independently of this machine.
 
 \subsection{Illustration: a 20-asset frontier}
 
@@ -1160,7 +1167,8 @@ the free and blocked sets at each turning point. The \texttt{cvxcla} implementat
 realises each step as a single block-eliminated KKT solve, hardens the event logic
 against degeneracy and floating-point noise, and abstracts the covariance behind a
 small operator protocol so that structured risk models obtain the same exact frontier
-at a fraction of the dense cost.
+without ever forming the dense matrix, and at a fraction of its cost when their
+structure is genuinely low-rank.
 
 \section*{Acknowledgements}
 \addcontentsline{toc}{section}{Acknowledgements}

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -93,20 +93,20 @@ efficient frontier \citep{wolfe1959, perold1984, niedermayer2010, bailey2013};
 while \citet{perold1984}, \citet{stein2008} and \citet{hirschberger2010} develop
 large-scale and active-set variants.
 
-We claim no new turning points --- the frontier is Markowitz's, and \texttt{cvxcla}
-traces exactly the same one --- but a new \emph{interface} to it: we capture the
+We claim no new turning points (the frontier is Markowitz's, and \texttt{cvxcla}
+traces exactly the same one) but a new \emph{interface} to it: we capture the
 covariance contract as three operations (a matrix--vector product, a free-block
 solve, and a free-to-blocked cross product) so that structured risk models trace
 the identical frontier without touching the algorithm. The one element here that
 is, to our knowledge, not standard in existing CLA
-implementations --- which operate on an explicit dense covariance
-\citep{markowitz2000, bailey2013} --- is this \emph{covariance-operator
+implementations (which operate on an explicit dense covariance
+\citep{markowitz2000, bailey2013}) is this \emph{covariance-operator
 abstraction}. The turning-point loop touches the covariance through only three
 operations: a matrix--vector product, a solve against the free-asset block, and a
 free-to-blocked cross product. Capturing exactly this contract as a small
 protocol decouples the algorithm from the covariance representation, so a
-structured risk model --- e.g.\ a diagonal-plus-low-rank factor covariance solved
-through the Woodbury identity --- drops in as a backend and traces the
+structured risk model (e.g.\ a diagonal-plus-low-rank factor covariance solved
+through the Woodbury identity) drops in as a backend and traces the
 \emph{same exact frontier} at a fraction of the cost, without a single change to
 the turning-point loop. This is the paper's main engineering contribution; the
 experiments of \S\ref{sec:experiment} quantify the resulting speed-up.
@@ -224,7 +224,7 @@ This portfolio is computed in closed form by \texttt{init\_algo}
 \item Walk down that order, raising each asset's weight from $\lb_i$ towards $\ub_i$,
       accumulating capital, until the budget $\sum_i w_i = 1$ is reached (within a
       floating-point tolerance). The last asset touched is only \emph{partially}
-      filled --- it absorbs the residual $1 - \sum_i w_i$ --- and is the single
+      filled (it absorbs the residual $1 - \sum_i w_i$) and is the single
       \emph{free} asset of the first turning point. All others are blocked, either at
       their lower bound (not yet reached) or upper bound (fully filled).
 \end{enumerate}
@@ -360,8 +360,8 @@ $\lambda^{\star} < 0$ the frontier is complete.
 \subsection{Anti-cycling on degenerate problems}
 \label{sec:bland}
 
-On degenerate problems --- tied expected returns, duplicated assets, or several
-constraints active at once --- multiple events can occur at the same ratio
+On degenerate problems (tied expected returns, duplicated assets, or several
+constraints active at once) multiple events can occur at the same ratio
 $\lambda^{\star}$. A naive ``pick any maximiser'' rule can cycle (the same partitions
 recurring without progress). The implementation uses a \textbf{Bland-style rule}: among
 all events within the tolerance of $\lambda^{\star}$ it selects the one with the lowest
@@ -372,7 +372,7 @@ Termination follows by the standard anti-cycling argument. There are only finite
 many free/blocked partitions (at most $2^{n}$), and each partition fixes the affine
 segment \eqref{eq:segment} and hence the interval of $\lambda$ over which it is
 optimal. The parameter $\lambda$ is non-increasing along the walk, so the only way to
-fail to terminate is to revisit a partition at the same $\lambda^{\star}$ --- a cycle.
+fail to terminate is to revisit a partition at the same $\lambda^{\star}$: a cycle.
 Bland's lowest-index selection rule rules this out exactly as it does for the simplex
 method: among the events tied at $\lambda^{\star}$ the deterministic lowest-index choice
 cannot generate a cyclic sequence of partitions. With cycles excluded and the partition
@@ -487,7 +487,7 @@ step; a non-positive or non-finite Schur pivot, or any free-set change that is n
 a single-asset flip, triggers a full refactorisation as a guard. For
 well-conditioned, positive-definite problems the two backends agree to solver
 precision, but on ill-conditioned or near-degenerate inputs the plain
-\texttt{DenseCovariance} --- or the factor backend below --- is the safer choice.
+\texttt{DenseCovariance}, or the factor backend below, is the safer choice.
 This backend is therefore offered as an opt-in fast path, not the default, and the
 win is dense-only: the factor backend never forms $\Sig_{\F\F}$ at all, so there is
 no inverse to maintain.
@@ -511,7 +511,7 @@ $\Sig_{\F\F}$; instead it uses the Woodbury identity
 W \;=\; \Delta\inv + U_\F\trans D_\F\inv U_\F \;\in\;\R^{k\times k},
 \end{equation}
 so a solve costs $O(n_\F k^2 + k^3)$ rather than $O(n_\F^3)$, and no $n\times n$ matrix
-is ever allocated --- memory and per-solve cost scale as $O(nk)$ instead of $O(n^2)$.
+is ever allocated: memory and per-solve cost scale as $O(nk)$ instead of $O(n^2)$.
 The cross product \eqref{eq:factor} contributes only through its low-rank part, since
 the diagonal has no off-diagonal block:
 \(
@@ -563,7 +563,7 @@ The list of turning points is wrapped in a \texttt{Frontier} object
 exposes its expected return $\mu\trans w$ and variance $w\trans\Sig w$. Between adjacent
 turning points the frontier in \emph{weight} space is the straight segment
 \eqref{eq:segment}, so the object can \texttt{interpolate} any number of intermediate
-portfolios by convex combination. Derived quantities --- volatility, Sharpe ratio --- are
+portfolios by convex combination. Derived quantities (volatility, Sharpe ratio) are
 computed pointwise. The maximum-Sharpe portfolio is found by a one-dimensional search
 over the convex combination of the two turning points bracketing the discrete Sharpe
 maximum, exploiting the same piecewise-linear weight structure.
@@ -629,7 +629,7 @@ single multi-right-hand-side solve against $\Sig_{\F\F}$ feeds an $m \times m$
 Schur complement \eqref{eq:schur} that handles the equality constraints, and the
 event search over all candidates is vectorised rather than looped. The $\alpha$
 and $\beta$ systems reuse the same factorisation, and the covariance enters only
-as a black-box solve --- which is what makes the backend abstraction possible.
+as a black-box solve, which is what makes the backend abstraction possible.
 
 \item \textbf{Constraint generality.} The reference implementation targets box
 bounds plus a single budget (fully-invested) constraint. \texttt{cvxcla} admits
@@ -650,7 +650,7 @@ block is declined (\S\ref{sec:empirical}).
 
 These differences compound into a large runtime gap (\S\ref{sec:experiment}). It
 would be tempting to dismiss the gap as ``just an implementation detail,'' but the
-reference implementation is not slow for lack of \texttt{numpy} --- it uses
+reference implementation is not slow for lack of \texttt{numpy}: it uses
 \texttt{numpy} for its per-step algebra. It is slow because of the structure
 above: a full free-block inverse rebuilt every step, and rebuilt once per
 candidate in the asset-entry search. \S\ref{sec:baseline} pins this down with a
@@ -664,9 +664,9 @@ develop parametric quadratic-programming and active-set methods aimed squarely a
 \emph{large} universes, and they too drive the per-step cost well below a dense
 $O(n_\F^3)$ refactorisation. The decisive difference is \emph{where} the speed-up
 comes from. Those methods accelerate the linear algebra of a covariance that is
-still treated as an explicit (if large and possibly sparse) matrix --- through
+still treated as an explicit (if large and possibly sparse) matrix (through
 incremental factorisation updates, exploitation of sparsity, or specialised
-pivoting --- so the gain is tied to a particular matrix representation baked into
+pivoting) so the gain is tied to a particular matrix representation baked into
 the solver. \texttt{cvxcla} instead leaves the turning-point loop entirely
 representation-agnostic: the covariance enters only through the three-operation
 operator protocol of \S\ref{sec:operators}, so the same loop runs unchanged on a
@@ -675,8 +675,8 @@ advantage of \S\ref{sec:rankscaling} is a property of the \emph{backend}, not of
 the algorithm. The two ideas are complementary rather than competing: an
 incremental-update solver for the free block could itself be wrapped as a
 \texttt{CovarianceOperator} and dropped in. A direct empirical comparison against
-these methods --- none of which ships a maintained Python implementation we are
-aware of --- is left to future work; the reading here is that \texttt{cvxcla}'s
+these methods (none of which ships a maintained Python implementation we are
+aware of) is left to future work; the reading here is that \texttt{cvxcla}'s
 contribution is the interface that makes such backends interchangeable, not a
 claim to the fastest dense large-scale solve.
 
@@ -684,8 +684,8 @@ claim to the fastest dense large-scale solve.
 \label{sec:experiment}
 
 To illustrate the algorithm we first trace the entire efficient frontier of a
-small problem --- small enough that its piecewise-linear corner structure is
-plainly visible --- and then measure how the runtime grows with the number of
+small problem (small enough that its piecewise-linear corner structure is
+plainly visible) and then measure how the runtime grows with the number of
 assets. Both experiments are reproducible from fixed random seeds:
 \srcfile{experiments/frontier_20x50.py}{experiments/frontier\_20x50.py} and
 \srcfile{experiments/runtime_scaling.py}{experiments/runtime\_scaling.py}.
@@ -706,7 +706,7 @@ milliseconds.
 \paragraph{Setup.}
 We simulate $T = 50$ daily returns for $N = 20$ assets from a $K = 5$ factor
 model. As the risk model we use the factor covariance itself,
-$\Sig = \operatorname{diag}(d) + U\,\Delta\,U\trans$ (standard practice --- a
+$\Sig = \operatorname{diag}(d) + U\,\Delta\,U\trans$ (standard practice, a
 structured risk model rather than the noisy sample covariance), and we estimate
 the expected returns $\mu \in \R^{20}$ by the sample mean over the $50$ days.
 We trace the long-only, fully-invested frontier, i.e.\ \eqref{eq:qp} with the
@@ -721,11 +721,11 @@ The piecewise-linear corners are clearly visible towards the low-variance end of
 the curve. Tracing this small problem takes on the order of a millisecond.
 Because the dense matrix and the structured \texttt{FactorCovariance} (Woodbury)
 backend represent the \emph{same} $\Sig$, the two backends return the identical
-$21$-point frontier --- the Woodbury identity is exact, so it changes only the
+$21$-point frontier: the Woodbury identity is exact, so it changes only the
 cost of each solve, never the result; its runtime advantage as the universe grows
 is the subject of \S\ref{sec:scaling}. (As an aside, replacing $\Sig$ by a
-low-rank \emph{approximation} of the full sample covariance --- its leading
-eigenpairs plus a diagonal residual --- yields a near-identical frontier differing
+low-rank \emph{approximation} of the full sample covariance (its leading
+eigenpairs plus a diagonal residual) yields a near-identical frontier differing
 by at most one corner, which is why factor risk models are a practical substitute
 for the raw sample covariance.)
 
@@ -763,7 +763,7 @@ factor backend: the dense per-iteration solve scales like $O(n_\F^3)$ over $O(n)
 iterations, while the Woodbury solve with fixed $K$ stays close to linear in $n$.
 The dense and factor backends are comparable for small universes (the Woodbury
 correction carries a fixed $K\times K$ overhead), but the factor backend pulls
-away as $n$ grows --- from rough parity at $n=40$ to a $\approx 9\times$ speedup
+away as $n$ grows: from rough parity at $n=40$ to a $\approx 9\times$ speedup
 at $n=640$ (Table~\ref{tab:scaling}). This $\approx 9\times$ is the genuine
 \emph{algorithmic} gain: both backends are vectorised \texttt{numpy} solving the
 identical $\Sig$, so the only difference is the asymptotic Woodbury advantage of
@@ -772,8 +772,8 @@ the structured solve over the dense one.
 For external context we also time PyPortfolioOpt, which scales far more steeply
 ($\approx n^{3.4}$): at $n=640$ it takes about $261$~seconds, so \texttt{cvxcla}'s
 dense backend is roughly $324\times$ faster and the factor backend roughly
-$2980\times$ faster. This gap is not a \texttt{numpy}-versus-Python artefact ---
-PyPortfolioOpt uses \texttt{numpy} for its linear algebra --- but a consequence of
+$2980\times$ faster. This gap is not a \texttt{numpy}-versus-Python artefact (
+PyPortfolioOpt uses \texttt{numpy} for its linear algebra) but a consequence of
 how it organises the work: it rebuilds a full free-block inverse at every step,
 and once per candidate in the asset-entry search (\S\ref{sec:bailey}).
 \S\ref{sec:baseline} separates this structural cost from the genuinely
@@ -794,8 +794,8 @@ $640$ & $641$ & $261{,}335$  & $337.9$ & $805.8$ & $87.7$ \\
 \bottomrule
 \end{tabular}
 \caption{Frontier trace time versus number of assets $n$ ($K=10$ factors). All
-four implementations are timed with the \emph{same} protocol --- the median of
-$3$ repetitions on the same machine and inputs --- and return the same
+four implementations are timed with the \emph{same} protocol (the median of
+$3$ repetitions on the same machine and inputs) and return the same
 $O(n)$-point frontier. ``Inverse baseline'' is the incremental-inverse CLA of
 \S\ref{sec:baseline} (\srcfile{experiments/inverse_cla.py}{experiments/inverse\_cla.py}): it shares
 \texttt{cvxcla}'s vectorised event logic but maintains $\Sig_{\F\F}\inv$ through
@@ -827,13 +827,13 @@ median of $3$ repetitions; the shaded band around each spans their min and max.}
 \label{sec:baseline}
 
 The $\approx 324\times$ gap between \texttt{cvxcla}'s dense backend and
-PyPortfolioOpt at $n=640$ invites a lazy explanation --- ``vectorised
-\texttt{numpy} versus slow Python'' --- that is wrong. PyPortfolioOpt already uses
+PyPortfolioOpt at $n=640$ invites a lazy explanation (``vectorised
+\texttt{numpy} versus slow Python'') that is wrong. PyPortfolioOpt already uses
 \texttt{numpy} (\texttt{np.linalg.inv}, \texttt{np.dot}) for its per-step linear
 algebra. It is slow because of \emph{how} it organises the work: it rebuilds a full
 inverse of the free block from scratch at every step, and in the branch that
 decides which blocked asset should re-enter it recomputes that full $O(n_\F^3)$
-inverse once for \emph{every} candidate blocked asset --- of order $n$ dense
+inverse once for \emph{every} candidate blocked asset, of order $n$ dense
 inverses per turning point. \texttt{cvxcla} instead forms the affine segment once
 per step from a single solve and evaluates all event candidates simultaneously
 (the $L$ matrix of \S\ref{sec:events}), so the gap is structural and algorithmic,
@@ -847,7 +847,7 @@ rank-one formulas do better? We test exactly this with a third implementation
 vectorised event logic but maintains $\Sig_{\F\F}\inv$ through rank-one bordered
 (asset enters) and deletion (asset leaves) updates, $O(n_\F^2)$ per step against
 the fresh solve's $O(n_\F^3)$. It is \emph{not} a reimplementation of
-PyPortfolioOpt --- it avoids PyPortfolioOpt's per-candidate rebuild --- and it
+PyPortfolioOpt (it avoids PyPortfolioOpt's per-candidate rebuild) and it
 traces the identical turning points to machine precision (max.\ weight discrepancy
 $<10^{-13}$ across $n=20$--$160$), so the comparison against the dense backend is
 clean: only the linear-algebra strategy differs.
@@ -856,12 +856,12 @@ The answer is yes: the incremental-inverse baseline ($\approx n^{2.0}$, $338$~ms
 $n=640$) is about $2.4\times$ \emph{faster} than the dense backend
 ($\approx n^{2.2}$, $806$~ms), exactly as the $O(n_\F^2)$-versus-$O(n_\F^3)$ count
 predicts. \texttt{cvxcla}'s block elimination is therefore not the fastest possible
-dense strategy --- and the package ships the incremental inverse as the opt-in
+dense strategy, and the package ships the incremental inverse as the opt-in
 \texttt{IncrementalDenseCovariance} backend (\S\ref{sec:incremental}) for callers
 who want that win. It is not the \emph{default} because the fresh solve is what
 composes cleanly with the covariance operator (\S\ref{sec:operators}) and is
 numerically robust step to step: the factor backend never forms $\Sig_{\F\F}$ at
-all, so there is no inverse to maintain --- it solves through the Woodbury
+all, so there is no inverse to maintain: it solves through the Woodbury
 identity. The default dense backend gives up the modest incremental-inverse win to
 keep one turning-point loop that runs over \emph{any} backend, and the factor
 backend more than repays it: at $n=640$ it is $\approx 9.2\times$ faster than the
@@ -884,7 +884,7 @@ and Table~\ref{tab:rank} show the crossover: the factor backend is $3.1\times$
 faster at $K=20$, reaches parity near $K=160$, and is about $2\times$ \emph{slower}
 at $K = 320$, where the ``low-rank'' part is full rank and the Woodbury correction
 is pure overhead. The practical reading is that the structured backend pays off
-precisely in the regime real risk models inhabit --- a few tens of factors over
+precisely in the regime real risk models inhabit: a few tens of factors over
 hundreds or thousands of assets ($K \ll n$).
 
 \begin{table}[h]
@@ -931,8 +931,8 @@ the $27$ interior segments, re-solve the parametric quadratic program
 \eqref{eq:qp} from scratch with a general convex solver (CVXPY/Clarabel
 \citep{cvxpy}, tight tolerances) and compare its optimiser against the CLA weights
 read off the segment by linear interpolation in $\lambda$. The agreement is at
-solver precision --- median weight discrepancy $5\times 10^{-8}$, maximum
-$1.3\times 10^{-5}$ --- confirming that the affine segments coincide with the QP
+solver precision (median weight discrepancy $5\times 10^{-8}$, maximum
+$1.3\times 10^{-5}$) confirming that the affine segments coincide with the QP
 optima rather than approximating them (\srcfile{experiments/validate_exact.py}{experiments/validate\_exact.py}).
 
 \subsection{Empirical example: the S\&P 500 frontier}
@@ -944,14 +944,14 @@ from Wikipedia and download five years of daily adjusted-close prices via
 \texttt{yfinance}, yielding $N = 494$ assets over $T = 1213$ trading days
 (2021-07-30 to 2026-05-29) after dropping thinly-traded names. From the
 full-history sample mean and covariance (condition number $\approx 1.1\times
-10^{5}$) the CLA traces the entire long-only frontier --- \textbf{96 turning
-points} --- in a median of $\approx 14$~ms (Figure~\ref{fig:realfrontier}); a
+10^{5}$) the CLA traces the entire long-only frontier (\textbf{96 turning
+points}) in a median of $\approx 14$~ms (Figure~\ref{fig:realfrontier}); a
 rank-$20$ diagonal-plus-low-rank approximation of the same covariance traces a
 near-identical frontier ($89$ turning points) in $\approx 9$~ms through the
 Woodbury backend. The annualised frontier spans expected returns of
 $0.14$--$0.89$ over volatilities of $0.10$--$0.87$, with a maximum Sharpe ratio of
-about $2.7$. This figure is measured in-sample --- the frontier is optimised over
-the same sample mean and covariance from which it is computed --- and so overstates
+about $2.7$. This figure is measured in-sample (the frontier is optimised over
+the same sample mean and covariance from which it is computed) and so overstates
 what is achievable out-of-sample; it is reported only to characterise the geometry
 of the frontier on a realistic problem, not as a claim of attainable performance.
 
@@ -1042,6 +1042,23 @@ homotopy in statistical learning \citep{tibshirani1996, osborne2000, efron2004}.
 Making the correspondence explicit places the CLA in a family it is seldom
 presented alongside, and separates the features that are essential to the method
 from those particular to the portfolio setting.
+
+The most direct relative is in control rather than statistics. The CLA is a
+one-parameter \emph{multi-parametric quadratic program} (mpQP): a strictly convex
+QP whose linear term depends affinely on a parameter, and whose solution map is
+therefore piecewise affine over a polyhedral partition of the parameter space. This
+is the structure exploited by explicit model predictive control, where the optimal
+control law is precomputed as a piecewise-affine function of the state by mpQP
+path-following \citep{bemporad2002, tondel2003}. The turning points of the CLA are
+the breakpoints of that map for the single risk-aversion parameter, and the event
+logic of \S\ref{sec:events} is the one-dimensional specialisation of the
+critical-region traversal used there. What the CLA does \emph{not} attempt, and what
+the general mpQP machinery handles, is arbitrary polyhedral constraints: its active
+set partitions the \emph{variables} into free and box-blocked, never a set of
+general inequality rows, so the reduced system is always a principal submatrix of
+$\Sig$ (\S\ref{sec:operators}) rather than a bordered KKT system. That restriction
+is exactly what keeps each step a single symmetric positive-definite solve, and it
+is the portfolio structure the method exploits.
 
 The LASSO solves, for a response $y$ and design matrix $X$,
 \[
@@ -1247,6 +1264,16 @@ S.~Rosset and J.~Zhu.
 J.~Brodie, I.~Daubechies, C.~De~Mol, D.~Giannone, and I.~Loris.
 \newblock Sparse and stable Markowitz portfolios.
 \newblock \emph{Proceedings of the National Academy of Sciences}, 106(30):12267--12272, 2009.
+
+\bibitem[Bemporad et~al.(2002)]{bemporad2002}
+A.~Bemporad, M.~Morari, V.~Dua, and E.~N. Pistikopoulos.
+\newblock The explicit linear quadratic regulator for constrained systems.
+\newblock \emph{Automatica}, 38(1):3--20, 2002.
+
+\bibitem[T\o ndel et~al.(2003)]{tondel2003}
+P.~T\o ndel, T.~A. Johansen, and A.~Bemporad.
+\newblock An algorithm for multi-parametric quadratic programming and explicit MPC solutions.
+\newblock \emph{Automatica}, 39(3):489--497, 2003.
 
 \end{thebibliography}
 

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -438,9 +438,11 @@ The turning-point loop touches the covariance matrix through only three operatio
 a full matrix--vector product $\Sig x$ (\texttt{matvec}); a solve against the free block,
 $\Sig_{\F\F}\inv R$ for a multi-column right-hand side $R$ (\texttt{solve\_free}); and a
 free-to-blocked cross product $\Sig_{\F\B}\,x_\B$ (\texttt{cross}). The package captures
-exactly this contract in the \texttt{CovarianceOperator} protocol
-(\texttt{src/cvxcla/operators.py}), so the algorithm never assumes an explicit matrix.
-Three backends implement it.
+exactly this contract in the \texttt{QuadraticForm} protocol
+(\texttt{src/cvxcla/operators.py}; \texttt{CovarianceOperator} remains as an alias),
+so the algorithm never assumes an explicit matrix. The name is deliberately not
+tied to covariance: the same contract is the Hessian of any quadratic objective, a
+point we return to in \S\ref{sec:lars}. Four backends implement it.
 
 \subsection{Dense covariance}
 
@@ -509,6 +511,41 @@ the diagonal has no off-diagonal block:
 \)
 Because the CLA accesses the covariance solely through the protocol, switching from a
 dense matrix to a factor model requires no change to the turning-point loop.
+
+\subsection{Data-matrix (Gram) covariance}
+\label{sec:gram}
+
+A sample covariance is itself a Gram matrix. If $X_c\in\R^{T\times n}$ is the
+column-centred matrix of $T$ return observations, then
+\begin{equation}
+\label{eq:gram}
+\Sig \;=\; \frac{1}{T-1}\,X_c\trans X_c,
+\end{equation}
+and \texttt{GramCovariance} implements the protocol straight from $X_c$, never
+forming the $n\times n$ matrix: \texttt{matvec} is the pair of thin products
+$X_c\trans(X_c x)/(T-1)$, \texttt{cross} restricts those products to the free and
+blocked columns, and \texttt{solve\_free} works on $X_{c\F}$ alone. Memory is
+$O(Tn)$ rather than $O(n^2)$.
+
+The catch is rank: $X_c\trans X_c$ has rank at most $T-1$. When there are at least as
+many observations as assets ($T\ge n$, with $X_c$ of full column rank) $\Sig$ is
+positive definite and this backend is the dense reference at lower memory. In the
+short-sample regime $T<n$ (a covariance estimated from far fewer periods than
+assets) $\Sig$ is singular, and the free block becomes unsolvable once the free set
+outgrows the data rank: exactly the degeneracy the algorithm detects through
+\texttt{rcond\_free}. An optional ridge $\delta I$ restores positive definiteness,
+and the free-block solve is then the Woodbury identity \eqref{eq:woodbury} carried
+out in the $T$-dimensional observation space (cost $O(n_\F T^2 + T^3)$). This is
+precisely a factor model \eqref{eq:factor} whose factors are the observations
+themselves ($U=X_c\trans$, $k=T$).
+
+This is a memory benefit, not an unconditional speed-up. When $T\ge n$ and the dense
+covariance fits in memory, \texttt{DenseCovariance} is faster per turning point: it
+slices a precomputed $\Sig_{\F\F}$, whereas the Gram backend re-forms
+$X_{c\F}\trans X_{c\F}$ at each solve. The same caveat governs the factor backend
+(\S\ref{sec:rankscaling}): a structured solve pays only while the rank, or here the
+observation count $T$, stays well below $n$; at full rank the structured route is
+slower than the plain dense matrix.
 
 \section{The efficient frontier object}
 \label{sec:frontier}
@@ -1073,7 +1110,11 @@ $\mu$. Seen this way, the covariance-operator abstraction of \S\ref{sec:operator
 the statement that the path-tracing logic touches $\Sig$ only through a few
 linear-algebraic operations, just as the LARS recursion touches $X$ only through
 Gram-matrix solves; a structured $\Sig$ (a factor model) is the portfolio analogue
-of a structured or kernelised design.
+of a structured or kernelised design. The package makes the correspondence literal:
+the \texttt{GramCovariance} backend (\S\ref{sec:gram}) builds $\Sig$ from the
+centred data matrix $X_c$ directly through \eqref{eq:gram}, so the CLA runs off
+$X_c$ exactly as LARS runs off the design matrix, and the protocol it calls is named
+\texttt{QuadraticForm} rather than after the covariance for this reason.
 
 The bridge is more than analogy. \citet{brodie2009} add a gross-exposure constraint
 $\|w\|_1 \le c$ to the Markowitz problem and show that the result \emph{is} a LASSO,

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -761,7 +761,11 @@ reference we also time the \texttt{CLA} of PyPortfolioOpt \citep{pyportfolioopt}
 a widely-used implementation of the critical-line algorithm of
 \citet{bailey2013}, on the same dense problem. The number of turning points tracks $n$ closely
 ($21, 42, 81, 159, 322, 641$ respectively, and PyPortfolioOpt finds essentially
-the same set), confirming the $O(n)$ count of \S\ref{sec:experiment}.
+the same set), confirming the $O(n)$ count of \S\ref{sec:experiment}. The two
+implementations also agree numerically: their minimum-variance portfolios (the
+$\lambda = 0$ endpoint, which is unique for a positive-definite $\Sig$) match to
+machine precision, differing by at most $\sim\!10^{-16}$ in any weight across these
+problems.
 
 Figure~\ref{fig:scaling} plots the median trace time against $n$ on log--log
 axes. A least-squares fit over the largest four sizes gives an empirical exponent

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -39,6 +39,12 @@
 \DeclareMathOperator*{\argmax}{arg\,max}
 \DeclareMathOperator*{\argmin}{arg\,min}
 
+% --- repository links ---------------------------------------------------
+% \srcfile{url-path}{display}: a clickable link to a file in the repository.
+% The url-path uses literal underscores; the display escapes them for \texttt.
+\newcommand{\repourl}{https://github.com/cvxgrp/cvxcla}
+\newcommand{\srcfile}[2]{\href{\repourl/blob/main/#1}{\texttt{#2}}}
+
 \title{\textbf{The Critical Line Algorithm}\\[0.3em]
 \large A parametric active-set method for the entire mean--variance efficient frontier,
 as implemented in \texttt{cvxcla}}
@@ -133,10 +139,12 @@ sub-tolerance round-off they produce back onto the feasible set
 (\S\ref{sec:empirical}), and a genuinely rank-deficient free block is the one
 case the algorithm declines rather than solve.
 
-This document describes the implementation in the \texttt{cvxcla} package. The core of
-the implementation is the class \texttt{CLA} in \texttt{src/cvxcla/cla.py}; it is
-supported by \texttt{first.py} (the starting portfolio), \texttt{operators.py} (the
-covariance backend), and \texttt{types.py} (the turning-point and frontier data
+This document describes the implementation in the \texttt{cvxcla}
+package.\footnote{\href{\repourl}{\texttt{github.com/cvxgrp/cvxcla}}} The core of
+the implementation is the class \texttt{CLA} in \srcfile{src/cvxcla/cla.py}{src/cvxcla/cla.py}; it is
+supported by \srcfile{src/cvxcla/first.py}{first.py} (the starting portfolio),
+\srcfile{src/cvxcla/operators.py}{operators.py} (the
+covariance backend), and \srcfile{src/cvxcla/types.py}{types.py} (the turning-point and frontier data
 structures). The notation below follows the code: $\mu$ is the vector of expected
 returns, $\Sig$ the covariance, $A,b$ the linear equality constraints, and $\lb,\ub$ the
 box bounds on the weights.
@@ -208,7 +216,7 @@ the partition $(\F,\B)$ must change, i.e.\ an endpoint of such an interval.
 The walk starts at $\lambda = +\infty$, where variance is irrelevant and \eqref{eq:qp}
 degenerates into ``earn the most expected return that the bounds and budget allow.''
 This portfolio is computed in closed form by \texttt{init\_algo}
-(\texttt{src/cvxcla/first.py}):
+(\srcfile{src/cvxcla/first.py}{src/cvxcla/first.py}):
 
 \begin{enumerate}
 \item Initialise every weight at its lower bound, $w \gets \lb$.
@@ -439,7 +447,7 @@ a full matrix--vector product $\Sig x$ (\texttt{matvec}); a solve against the fr
 $\Sig_{\F\F}\inv R$ for a multi-column right-hand side $R$ (\texttt{solve\_free}); and a
 free-to-blocked cross product $\Sig_{\F\B}\,x_\B$ (\texttt{cross}). The package captures
 exactly this contract in the \texttt{QuadraticForm} protocol
-(\texttt{src/cvxcla/operators.py}; \texttt{CovarianceOperator} remains as an alias),
+(\srcfile{src/cvxcla/operators.py}{src/cvxcla/operators.py}; \texttt{CovarianceOperator} remains as an alias),
 so the algorithm never assumes an explicit matrix. The name is deliberately not
 tied to covariance: the same contract is the Hessian of any quadratic objective, a
 point we return to in \S\ref{sec:lars}. Four backends implement it.
@@ -551,7 +559,7 @@ slower than the plain dense matrix.
 \label{sec:frontier}
 
 The list of turning points is wrapped in a \texttt{Frontier} object
-(\texttt{src/cvxcla/types.py}). Each \texttt{FrontierPoint} carries a weight vector and
+(\srcfile{src/cvxcla/types.py}{src/cvxcla/types.py}). Each \texttt{FrontierPoint} carries a weight vector and
 exposes its expected return $\mu\trans w$ and variance $w\trans\Sig w$. Between adjacent
 turning points the frontier in \emph{weight} space is the straight segment
 \eqref{eq:segment}, so the object can \texttt{interpolate} any number of intermediate
@@ -679,8 +687,8 @@ To illustrate the algorithm we first trace the entire efficient frontier of a
 small problem --- small enough that its piecewise-linear corner structure is
 plainly visible --- and then measure how the runtime grows with the number of
 assets. Both experiments are reproducible from fixed random seeds:
-\texttt{experiments/frontier\_20x50.py} and
-\texttt{experiments/runtime\_scaling.py}.
+\srcfile{experiments/frontier_20x50.py}{experiments/frontier\_20x50.py} and
+\srcfile{experiments/runtime_scaling.py}{experiments/runtime\_scaling.py}.
 
 \paragraph{Benchmark environment.}
 The runtime study below (the scaling sweep of \S\ref{sec:scaling} and the rank
@@ -789,7 +797,7 @@ $640$ & $641$ & $261{,}335$  & $337.9$ & $805.8$ & $87.7$ \\
 four implementations are timed with the \emph{same} protocol --- the median of
 $3$ repetitions on the same machine and inputs --- and return the same
 $O(n)$-point frontier. ``Inverse baseline'' is the incremental-inverse CLA of
-\S\ref{sec:baseline} (\texttt{experiments/inverse\_cla.py}): it shares
+\S\ref{sec:baseline} (\srcfile{experiments/inverse_cla.py}{experiments/inverse\_cla.py}): it shares
 \texttt{cvxcla}'s vectorised event logic but maintains $\Sig_{\F\F}\inv$ through
 rank-one updates instead of re-solving each step, so the gap between it and the
 dense backend isolates the linear-algebra strategy. Empirically the times scale
@@ -835,7 +843,7 @@ That still leaves a fair question about \texttt{cvxcla}'s own dense backend: it 
 re-solves from scratch each step, discarding the previous factorisation. Could a
 CLA that instead \emph{maintains} the free-block inverse and updates it by
 rank-one formulas do better? We test exactly this with a third implementation
-(\texttt{experiments/inverse\_cla.py}): a CLA that shares \texttt{cvxcla}'s
+(\srcfile{experiments/inverse_cla.py}{experiments/inverse\_cla.py}): a CLA that shares \texttt{cvxcla}'s
 vectorised event logic but maintains $\Sig_{\F\F}\inv$ through rank-one bordered
 (asset enters) and deletion (asset leaves) updates, $O(n_\F^2)$ per step against
 the fresh solve's $O(n_\F^3)$. It is \emph{not} a reimplementation of
@@ -925,13 +933,13 @@ the $27$ interior segments, re-solve the parametric quadratic program
 read off the segment by linear interpolation in $\lambda$. The agreement is at
 solver precision --- median weight discrepancy $5\times 10^{-8}$, maximum
 $1.3\times 10^{-5}$ --- confirming that the affine segments coincide with the QP
-optima rather than approximating them (\texttt{experiments/validate\_exact.py}).
+optima rather than approximating them (\srcfile{experiments/validate_exact.py}{experiments/validate\_exact.py}).
 
 \subsection{Empirical example: the S\&P 500 frontier}
 \label{sec:empirical}
 
 To close, we run the algorithm on real data. Using
-\texttt{experiments/fetch\_sp500.py} we pull the current S\&P 500 constituents
+\srcfile{experiments/fetch_sp500.py}{experiments/fetch\_sp500.py} we pull the current S\&P 500 constituents
 from Wikipedia and download five years of daily adjusted-close prices via
 \texttt{yfinance}, yielding $N = 494$ assets over $T = 1213$ trading days
 (2021-07-30 to 2026-05-29) after dropping thinly-traded names. From the
@@ -999,7 +1007,7 @@ optimal; when it does not, the algorithm declines rather than mislead. A
 well-conditioned, full-rank estimate (ample history, or a structured
 \texttt{FactorCovariance}, which is positive definite by construction) stays in
 the first regime. The experiment is reproducible from
-\texttt{experiments/degeneracy\_boundary.py}.
+\srcfile{experiments/degeneracy_boundary.py}{experiments/degeneracy\_boundary.py}.
 
 \begin{figure}[h]
 \centering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ version = "1.7.0"
 description = "Critical line algorithm for the efficient frontier"
 readme = "README.md"
 requires-python = ">=3.11"
-license = "Apache-2.0"
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: MIT License",
 ]
 # Private :: Do Not Upload (prevents rhiza_release.yml from publishing to PyPI)
 

--- a/src/cvxcla/__init__.py
+++ b/src/cvxcla/__init__.py
@@ -17,6 +17,7 @@ from .operators import (
     CovarianceOperator,
     DenseCovariance,
     FactorCovariance,
+    GramCovariance,
     IncrementalDenseCovariance,
     QuadraticForm,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "CovarianceOperator",
     "DenseCovariance",
     "FactorCovariance",
+    "GramCovariance",
     "IncrementalDenseCovariance",
     "Lasso",
     "ParametricProblem",

--- a/src/cvxcla/__init__.py
+++ b/src/cvxcla/__init__.py
@@ -1,16 +1,3 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
 """Critical Line Algorithm (CLA) for Portfolio Optimization.
 
 This package implements the Critical Line Algorithm introduced by Harry Markowitz
@@ -25,12 +12,15 @@ methods to compute and analyze the efficient frontier.
 import importlib.metadata
 
 from .cla import CLA
+from .lasso import Lasso
 from .operators import (
     CovarianceOperator,
     DenseCovariance,
     FactorCovariance,
     IncrementalDenseCovariance,
+    QuadraticForm,
 )
+from .pathtracer import ParametricProblem, trace
 
 __all__ = [
     "CLA",
@@ -38,6 +28,10 @@ __all__ = [
     "DenseCovariance",
     "FactorCovariance",
     "IncrementalDenseCovariance",
+    "Lasso",
+    "ParametricProblem",
+    "QuadraticForm",
+    "trace",
 ]
 
 try:

--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -1,16 +1,3 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
 """Markowitz implementation of the Critical Line Algorithm.
 
 This module provides the CLA class, which implements the Critical Line Algorithm
@@ -22,13 +9,33 @@ set of assets at their bounds changes.
 import logging
 from dataclasses import dataclass, field
 from functools import cached_property
+from typing import NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
 
 from .first import init_algo
-from .operators import CovarianceOperator, DenseCovariance
+from .operators import DenseCovariance, QuadraticForm
+from .pathtracer import trace
 from .types import Frontier, FrontierPoint, TurningPoint
+
+
+class _Segment(NamedTuple):
+    """The affine critical-line segment valid at one turning point.
+
+    Bundles the affine path ``w(lam) = r_alpha + lam * r_beta``, the multiplier
+    gradients ``gamma``/``delta`` that drive the leave-a-bound events, and the
+    active-set masks the event scan needs. This is what ``CLA.segment`` returns
+    to the generic path tracer.
+    """
+
+    r_alpha: NDArray[np.float64]
+    r_beta: NDArray[np.float64]
+    gamma: NDArray[np.float64]
+    delta: NDArray[np.float64]
+    at_upper: NDArray[np.bool_]
+    at_lower: NDArray[np.bool_]
+    free_in: NDArray[np.bool_]
 
 
 @dataclass(frozen=True)
@@ -59,7 +66,7 @@ class CLA:
     """
 
     mean: NDArray[np.float64]
-    covariance: NDArray[np.float64] | CovarianceOperator
+    covariance: NDArray[np.float64] | QuadraticForm
     lower_bounds: NDArray[np.float64]
     upper_bounds: NDArray[np.float64]
     a: NDArray[np.float64]
@@ -69,16 +76,21 @@ class CLA:
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
 
     @cached_property
-    def covariance_operator(self) -> CovarianceOperator:
-        """Return the covariance as a ``CovarianceOperator`` backend.
+    def covariance_operator(self) -> QuadraticForm:
+        """Return the covariance as a ``QuadraticForm`` backend.
 
         A plain ``numpy`` covariance matrix is wrapped in ``DenseCovariance``;
         an object already implementing the protocol is passed through. This is
         the single point where the input form is normalised.
         """
-        if isinstance(self.covariance, CovarianceOperator):
+        if isinstance(self.covariance, QuadraticForm):
             return self.covariance
         return DenseCovariance(self.covariance)
+
+    @property
+    def dimension(self) -> int:
+        """Number of assets ``n`` (the problem dimension for the path tracer)."""
+        return len(self.mean)
 
     def __post_init__(self) -> None:
         """Initialize the CLA object and compute the efficient frontier.
@@ -89,58 +101,73 @@ class CLA:
         computing the next turning point with a lower expected return until
         it reaches the minimum variance portfolio.
 
+        The actual walk is driven by the generic ``cvxcla.pathtracer.trace``
+        loop; this class supplies the portfolio-specific hooks (``begin``,
+        ``segment``, ``event_matrix``, ``step``, ``finish``) it calls.
+
         The reduced KKT system at each turning point is solved by block
         elimination: two multi-RHS solves against the free covariance block
         (via the covariance backend) and a small m x m Schur complement
         ``A_F @ Sigma_FF^{-1} @ A_F.T``, where m is the number of equality
-        constraints. The covariance only enters through the
-        ``CovarianceOperator`` interface, so structured backends (e.g.
-        ``FactorCovariance``) never materialise an n x n matrix.
+        constraints. The covariance only enters through the ``QuadraticForm``
+        interface, so structured backends (e.g. ``FactorCovariance``) never
+        materialise an n x n matrix.
 
         Raises:
             RuntimeError: If all variables are blocked, which would make the
                           system of equations singular.
 
         """
-        ns = len(self.mean)
+        trace(self)
 
-        # Compute and store the first turning point
-        self._append(self._first_turning_point())
+    def begin(self) -> tuple[float, TurningPoint]:
+        """Record the first turning point and start the trace at ``lambda = inf``.
 
-        lam = np.inf
+        Returns:
+            ``(inf, first_turning_point)``: the starting lambda bound and the
+            initial state for the path tracer.
+        """
+        first = self._first_turning_point()
+        self._append(first)
+        return np.inf, first
 
-        # Safety bound: each iteration fixes the activity of at least one asset,
-        # so a correct trace runs O(ns) times. Far exceeding this means the event
-        # loop failed to terminate (e.g. cycling); fail loudly instead of hanging.
-        # The bound is far above any valid frontier length.
-        max_iterations = 100 * (ns + 1)  # pragma: no mutate
-        iterations = 0  # pragma: no mutate
+    def segment(self, state: TurningPoint) -> _Segment:
+        """Solve the reduced KKT system for the critical-line segment at ``state``."""
+        at_upper, at_lower, free_in, fixed_weights = self._active_set(state)
+        r_alpha, r_beta, gamma, delta = self._solve_kkt(free_in, fixed_weights)
+        return _Segment(r_alpha, r_beta, gamma, delta, at_upper, at_lower, free_in)
 
-        while lam > 0:  # pragma: no mutate
-            iterations += 1  # pragma: no mutate
-            if iterations > max_iterations:  # pragma: no mutate
-                msg = "CLA failed to converge: too many iterations"  # pragma: no mutate
-                raise RuntimeError(msg)  # pragma: no mutate
-            last = self.turning_points[-1]
+    def event_matrix(self, state: TurningPoint, segment: _Segment) -> NDArray[np.float64]:  # noqa: ARG002
+        """Return the ``(n, 4)`` matrix of candidate critical lambdas for ``segment``.
 
-            at_upper, at_lower, free_in, fixed_weights = self._active_set(last)
-            r_alpha, r_beta, gamma, delta = self._solve_kkt(free_in, fixed_weights)
-            l_mat = self._event_ratios(r_alpha, r_beta, gamma, delta, free_in, at_upper, at_lower)
+        ``state`` is part of the uniform ``ParametricProblem`` signature; the CLA
+        does not need it here because ``segment`` already bundles the active-set
+        masks derived from it.
+        """
+        return self._event_ratios(
+            segment.r_alpha,
+            segment.r_beta,
+            segment.gamma,
+            segment.delta,
+            segment.free_in,
+            segment.at_upper,
+            segment.at_lower,
+        )
 
-            event = self._select_next_event(l_mat, lam)
-            if event is None:
-                break
-            secchg, dirchg, lam = event
+    def step(self, state: TurningPoint, segment: _Segment, sec: int, direction: int, lam: float) -> TurningPoint:
+        """Emit the turning point at ``lam`` after flipping asset ``sec``'s activity.
 
-            # Flip the activity of the asset whose event fired: a "leaves a bound"
-            # event (dirchg in {2, 3}) makes it free, a "moves to a bound" event
-            # (dirchg in {0, 1}) blocks it.
-            free = last.free.copy()
-            free[secchg] = dirchg >= 2
-            self._emit(lam, r_alpha + lam * r_beta, free)
+        A "leaves a bound" event (``direction`` in {2, 3}) makes the asset free; a
+        "moves to a bound" event (``direction`` in {0, 1}) blocks it.
+        """
+        free = state.free.copy()
+        free[sec] = direction >= 2
+        self._emit(lam, segment.r_alpha + lam * segment.r_beta, free)
+        return self.turning_points[-1]
 
-        # Final point at lambda = 0
-        self._emit(0.0, r_alpha, last.free)
+    def finish(self, state: TurningPoint, segment: _Segment) -> None:
+        """Emit the minimum-variance endpoint at ``lambda = 0``."""
+        self._emit(0.0, segment.r_alpha, state.free)
 
     def _active_set(
         self, last: TurningPoint
@@ -288,37 +315,6 @@ class CLA:
         l_mat[delta_down, 2] = -gamma[delta_down] / delta[delta_down]  # pragma: no mutate
         l_mat[delta_up, 3] = -gamma[delta_up] / delta[delta_up]
         return l_mat
-
-    def _select_next_event(self, l_mat: NDArray[np.float64], lam: float) -> tuple[int, int, float] | None:
-        """Pick the next turning point from the event matrix, or ``None`` to stop.
-
-        The current segment is valid only for lam at or below the current value
-        (the frontier is traced with non-increasing lam), so ratios above it are
-        spurious crossings outside the segment and are discarded; if none remain
-        the trace is complete. Among events tied (within ``tol``) for the largest
-        valid ratio, a Bland-style lowest-(asset index, event type) rule makes the
-        choice deterministic and prevents cycling on degenerate problems (tied
-        means, duplicated assets).
-
-        Args:
-            l_mat: The ``(n, 4)`` matrix of candidate critical lambdas.
-            lam: The current (upper) lambda bound on valid events.
-
-        Returns:
-            ``(secchg, dirchg, lam_next)`` for the chosen event, or ``None`` if no
-            valid event remains.
-        """
-        tol = self.tol
-        l_mat = l_mat.copy()  # do not mutate the caller's matrix
-        l_mat[l_mat > lam + tol] = -np.inf  # pragma: no mutate
-
-        lam_max = np.max(l_mat)
-        if lam_max < 0:  # pragma: no mutate
-            return None
-
-        tied = np.argwhere(l_mat >= lam_max - tol)  # pragma: no mutate
-        secchg, dirchg = tied[0]
-        return int(secchg), int(dirchg), float(l_mat[secchg, dirchg])
 
     def __len__(self) -> int:
         """Get the number of turning points in the efficient frontier.

--- a/src/cvxcla/first.py
+++ b/src/cvxcla/first.py
@@ -1,16 +1,3 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
 """First turning point computation for the Critical Line Algorithm.
 
 This module provides functions to compute the first turning point on the efficient frontier,

--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -1,0 +1,257 @@
+"""LASSO / LARS regularisation path as a parametric active-set problem.
+
+This module shows that the Critical Line Algorithm's machinery is not specific to
+portfolios: the *same* ``cvxcla.pathtracer.trace`` loop, the *same*
+``QuadraticForm`` operator, and the *same* Bland event selection trace the LASSO
+homotopy. Only the problem-specific glue (the segment solve and what an event
+means) differs.
+
+The LASSO solves, for a response ``y`` and design matrix ``X``,
+
+    minimize  1/2 ||y - X beta||^2 + lam ||beta||_1
+
+and its minimiser ``beta(lam)`` is continuous and piecewise linear in the penalty
+``lam``. On a segment where the active set ``A`` (the support) and the signs
+``s_A`` are fixed,
+
+    beta_A(lam)      = (X_A^T X_A)^{-1} (X_A^T y - lam s_A) = alpha_A - lam * beta_slope_A
+    correlation(lam) = X^T (y - X beta(lam))               = p + lam * q
+
+with ``|correlation_j| <= lam`` off the support and ``correlation_j = lam s_j`` on
+it. The role played by the covariance ``Sigma`` and mean ``mu`` in the CLA is
+played here by the Gram matrix ``H = X^T X`` (wrapped in ``DenseCovariance``) and
+the vector ``X^T y``.
+
+Two coordinate-indexed event families, mirroring the CLA's "move to / leave a
+bound":
+
+* **leave** -- an active coefficient reaches zero: ``lam = alpha_j / beta_slope_j``.
+* **enter** -- an inactive correlation reaches ``+/-lam``: ``p_j + lam q_j = +/-lam``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import pairwise
+from typing import NamedTuple
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .operators import DenseCovariance, QuadraticForm
+from .pathtracer import trace
+
+
+class _LassoState(NamedTuple):
+    """The active set, sign pattern, and current penalty defining the segment.
+
+    ``lam`` is the penalty at the segment's upper end. The event scan uses it to
+    require *strict* progress to a smaller penalty: right after a coefficient
+    enters it sits at zero, so its leave event lies at the current ``lam``; without
+    the strict window the shared selector would re-fire it and the walk would cycle
+    between entering and leaving the same coordinate.
+    """
+
+    active: NDArray[np.bool_]
+    signs: NDArray[np.float64]
+    lam: float
+
+
+class _LassoSegment(NamedTuple):
+    """The affine path ``beta(lam) = alpha - lam * beta_slope`` and correlation ``p + lam * q``."""
+
+    alpha: NDArray[np.float64]
+    beta_slope: NDArray[np.float64]
+    p: NDArray[np.float64]
+    q: NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class Breakpoint:
+    """A vertex of the piecewise-linear LASSO path.
+
+    Attributes:
+        lam: The penalty value at this breakpoint.
+        beta: The coefficient vector ``beta(lam)``.
+        active: Boolean mask of the support (non-zero coefficients) on the
+            segment leaving this breakpoint towards smaller ``lam``.
+    """
+
+    lam: float
+    beta: NDArray[np.float64]
+    active: NDArray[np.bool_]
+
+
+@dataclass
+class Lasso:
+    """The LASSO regularisation path, traced as a parametric active-set problem.
+
+    Constructing a ``Lasso`` traces the entire path from ``lam_max`` (where
+    ``beta = 0``) down to ``lam = 0`` (the ordinary least-squares fit on the final
+    support), storing the breakpoints in ``path``. The walk is driven by the same
+    ``cvxcla.pathtracer.trace`` loop as the Critical Line Algorithm.
+
+    Attributes:
+        x: Design matrix of shape ``(m, n)``.
+        y: Response vector of shape ``(m,)``.
+        tol: Tolerance for event selection and the validity window.
+        path: The discovered breakpoints, populated on construction.
+    """
+
+    x: NDArray[np.float64]
+    y: NDArray[np.float64]
+    tol: float = 1e-9  # pragma: no mutate
+    path: list[Breakpoint] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate shapes and trace the full LASSO path.
+
+        Raises:
+            ValueError: If ``x`` is not 2d or ``y``'s length does not match the
+                number of rows of ``x``.
+        """
+        if self.x.ndim != 2:
+            msg = f"x must be a 2d design matrix, got shape {self.x.shape}"
+            raise ValueError(msg)
+        if self.y.shape != (self.x.shape[0],):
+            msg = f"y must have shape ({self.x.shape[0]},), got {self.y.shape}"
+            raise ValueError(msg)
+        trace(self)
+
+    @property
+    def quad(self) -> QuadraticForm:
+        """The Gram matrix ``X^T X`` as a ``QuadraticForm`` backend."""
+        return DenseCovariance(self.x.T @ self.x)
+
+    @property
+    def xty(self) -> NDArray[np.float64]:
+        """The linear data ``X^T y`` (the analogue of the CLA's expected returns)."""
+        return self.x.T @ self.y
+
+    @property
+    def dimension(self) -> int:
+        """Number of features ``n`` (the problem dimension for the path tracer)."""
+        return int(self.x.shape[1])
+
+    @property
+    def lam_max(self) -> float:
+        """The smallest penalty at which ``beta = 0`` is optimal: ``||X^T y||_inf``."""
+        return float(np.max(np.abs(self.xty)))
+
+    def begin(self) -> tuple[float, _LassoState]:
+        """Record the all-zero solution at ``lam_max`` and enter the first coordinate.
+
+        Returns:
+            ``(lam_max, state)`` where ``state`` already has the most-correlated
+            coordinate in the active set, mirroring the CLA's first turning point.
+        """
+        n = self.dimension
+        xty = self.xty
+        lam_max = self.lam_max
+        j0 = int(np.argmax(np.abs(xty)))
+        self.path.append(Breakpoint(lam_max, np.zeros(n), np.zeros(n, dtype=bool)))
+
+        active = np.zeros(n, dtype=bool)
+        active[j0] = True
+        signs = np.zeros(n)
+        signs[j0] = np.sign(xty[j0])
+        return lam_max, _LassoState(active, signs, lam_max)
+
+    def segment(self, state: _LassoState) -> _LassoSegment:
+        """Solve the affine segment for the current ``(active, signs)`` state.
+
+        Both solves go through the ``QuadraticForm`` principal-submatrix solver,
+        exactly as the CLA solves against the free covariance block.
+        """
+        n = self.dimension
+        active, signs = state.active, state.signs
+        alpha = np.zeros(n)
+        beta_slope = np.zeros(n)
+        alpha[active] = self.quad.solve_free(active, self.xty[active])
+        beta_slope[active] = self.quad.solve_free(active, signs[active])
+
+        # correlation(lam) = X^T y - H beta(lam) = (xty - H alpha) + lam (H beta_slope)
+        p = self.xty - self.quad.matvec(alpha)
+        q = self.quad.matvec(beta_slope)
+        return _LassoSegment(alpha, beta_slope, p, q)
+
+    def event_matrix(self, state: _LassoState, segment: _LassoSegment) -> NDArray[np.float64]:
+        """Return the ``(n, 3)`` matrix of candidate critical lambdas.
+
+        Columns: 0 = leave (active coefficient hits zero), 1 = enter with sign
+        ``+1`` (inactive correlation reaches ``+lam``), 2 = enter with sign ``-1``
+        (reaches ``-lam``). Only events strictly above ``tol`` are kept, so the
+        trace stops cleanly as ``lam`` approaches zero.
+        """
+        n = self.dimension
+        active = state.active
+        inactive = ~active
+        alpha, beta_slope, p, q = segment
+
+        l_mat = np.full((n, 3), -np.inf)
+
+        # leave: alpha_j - lam beta_slope_j = 0
+        leaves = active & (np.abs(beta_slope) > self.tol)  # pragma: no mutate
+        l_mat[leaves, 0] = alpha[leaves] / beta_slope[leaves]
+
+        # enter (+): p_j + lam q_j = +lam -> lam = p_j / (1 - q_j)
+        denom_pos = 1.0 - q
+        enters_pos = inactive & (np.abs(denom_pos) > self.tol)  # pragma: no mutate
+        l_mat[enters_pos, 1] = p[enters_pos] / denom_pos[enters_pos]
+
+        # enter (-): p_j + lam q_j = -lam -> lam = -p_j / (1 + q_j)
+        denom_neg = 1.0 + q
+        enters_neg = inactive & (np.abs(denom_neg) > self.tol)  # pragma: no mutate
+        l_mat[enters_neg, 2] = -p[enters_neg] / denom_neg[enters_neg]
+
+        # Keep only events that make strict progress to a smaller, positive penalty:
+        # at or above the current lam they are the spurious inverse of the coordinate
+        # just flipped (which would cycle); at or below ~0 the path is complete.
+        l_mat[(l_mat <= self.tol) | (l_mat >= state.lam - self.tol)] = -np.inf
+        return l_mat
+
+    def step(self, state: _LassoState, segment: _LassoSegment, sec: int, direction: int, lam: float) -> _LassoState:
+        """Record the breakpoint at ``lam`` after flipping coordinate ``sec``.
+
+        ``direction`` 0 removes ``sec`` from the support; 1/2 add it with sign
+        ``+1``/``-1``. The recorded coefficients are the old segment evaluated at
+        ``lam`` (the path is continuous across the flip).
+        """
+        active = state.active.copy()
+        signs = state.signs.copy()
+        if direction == 0:
+            active[sec] = False
+            signs[sec] = 0.0
+        else:
+            active[sec] = True
+            signs[sec] = 1.0 if direction == 1 else -1.0
+
+        beta = segment.alpha - lam * segment.beta_slope
+        self.path.append(Breakpoint(lam, beta, active.copy()))
+        return _LassoState(active, signs, lam)
+
+    def finish(self, state: _LassoState, segment: _LassoSegment) -> None:
+        """Record the ``lam = 0`` endpoint: the least-squares fit on the final support."""
+        self.path.append(Breakpoint(0.0, segment.alpha.copy(), state.active.copy()))
+
+    def solution(self, lam: float) -> NDArray[np.float64]:
+        """Evaluate the piecewise-linear path at penalty ``lam``.
+
+        Args:
+            lam: The penalty value at which to evaluate ``beta``.
+
+        Returns:
+            The coefficient vector ``beta(lam)``, by linear interpolation between
+            the bracketing breakpoints (clamped to the path's endpoints).
+        """
+        ordered = sorted(self.path, key=lambda bp: bp.lam)
+        if lam <= ordered[0].lam:
+            return ordered[0].beta
+        if lam >= ordered[-1].lam:
+            return ordered[-1].beta
+        for lo, hi in pairwise(ordered):
+            if lo.lam <= lam <= hi.lam:
+                weight = (lam - lo.lam) / (hi.lam - lo.lam)
+                return (1.0 - weight) * lo.beta + weight * hi.beta
+        msg = "lam lies within the path range but no bracketing segment was found"  # pragma: no cover
+        raise AssertionError(msg)  # pragma: no cover

--- a/src/cvxcla/operators.py
+++ b/src/cvxcla/operators.py
@@ -1,16 +1,3 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
 """Covariance backend abstraction for the Critical Line Algorithm.
 
 The turning-point loop of the CLA touches the covariance matrix through a
@@ -58,19 +45,29 @@ def _rcond_symmetric(block: NDArray[np.float64]) -> float:
 
 
 @runtime_checkable
-class CovarianceOperator(Protocol):
-    """Operations the Critical Line Algorithm needs from a covariance matrix.
+class QuadraticForm(Protocol):
+    """Operations a parametric active-set path tracer needs from its Hessian.
 
-    Any object implementing this protocol can serve as the covariance backend
-    of the CLA. The reference implementation is ``DenseCovariance``, which
-    wraps an explicit matrix; structured backends (e.g. diagonal-plus-low-rank
-    via the Woodbury identity) implement the same contract without ever
-    materialising an ``n x n`` matrix.
+    The turning-point loop touches the symmetric positive (semi-)definite matrix
+    ``H`` of the quadratic objective through a small number of operations: full
+    matrix-vector products, solves against the *free* (active) principal block,
+    and cross-products between free and blocked coordinates. In the Critical Line
+    Algorithm ``H`` is the covariance ``Sigma``; in a LASSO / LARS path it is the
+    Gram matrix ``X.T @ X``. Any object implementing this protocol can serve as
+    that backend.
+
+    The reference implementation is ``DenseCovariance``, which wraps an explicit
+    matrix; structured backends (e.g. diagonal-plus-low-rank via the Woodbury
+    identity) implement the same contract without ever materialising an
+    ``n x n`` matrix.
+
+    ``CovarianceOperator`` is kept as a backward-compatible alias of this
+    protocol (see the bottom of this module).
     """
 
     @property
     def n(self) -> int:
-        """Number of assets (the dimension of the covariance)."""
+        """Number of variables (the dimension of the quadratic form)."""
         ...  # pragma: no cover
 
     def matvec(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
@@ -557,3 +554,10 @@ class FactorCovariance:
         delta_max = float(np.linalg.eigvalsh(self._delta_matrix)[-1])
         lam_max_upper = float(np.max(d_free)) + u_spectral_norm**2 * max(delta_max, 0.0)
         return float(np.min(d_free)) / lam_max_upper
+
+
+# Backward-compatible alias. The protocol was introduced as ``CovarianceOperator``
+# for the portfolio (covariance) setting; it is the Hessian contract for any
+# parametric active-set path, so the canonical name is now ``QuadraticForm``.
+# Existing imports of ``CovarianceOperator`` keep working unchanged.
+CovarianceOperator = QuadraticForm

--- a/src/cvxcla/operators.py
+++ b/src/cvxcla/operators.py
@@ -556,6 +556,193 @@ class FactorCovariance:
         return float(np.min(d_free)) / lam_max_upper
 
 
+@dataclass(frozen=True)
+class GramCovariance:
+    """Sample covariance backed by the data matrix, never forming ``Sigma``.
+
+    A sample covariance *is* a (scaled, centered) Gram matrix:
+    ``Sigma = X_c^T X_c / (T - 1)`` where ``X_c`` is the column-centered
+    ``(T, n)`` returns matrix. This backend stores only ``X_c`` (``O(T n)``
+    memory) and implements the ``QuadraticForm`` protocol straight from it, so
+    the ``n x n`` covariance is never materialised: ``matvec`` is two thin
+    products ``X_c^T (X_c v)``, and ``solve_free`` works on the free columns of
+    ``X_c`` alone.
+
+    An optional ridge ``delta >= 0`` represents ``Sigma = X_c^T X_c / (T - 1) +
+    delta I``. It matters because ``X_c^T X_c`` has rank at most ``T - 1``: when
+    there are fewer observations than assets (``T <= n``) the raw covariance is
+    singular and the free block becomes unsolvable once the free set outgrows the
+    data rank (the degeneracy the CLA detects via ``rcond_free``). A positive
+    ridge restores positive definiteness, and the free-block solve is then done by
+    the Woodbury identity in the ``T``-dimensional observation space
+    (``O(n_F T^2 + T^3)``) whenever that is cheaper than the ``n_F x n_F`` normal
+    equations -- i.e. this is a factor model whose factors are the observations.
+
+    When to use:
+        This is a *memory* play, not an unconditional speed-up. Its win is the
+        short-sample regime ``T < n`` (a sample covariance from far fewer periods
+        than assets), where it never forms the ``n x n`` matrix and the
+        ridge + Woodbury solve works in the small ``T``-space. When ``T >= n`` and
+        the dense covariance fits in memory, ``DenseCovariance`` is faster per
+        turning point: it slices a *precomputed* ``Sigma_FF`` once, whereas this
+        backend re-forms ``X_cF^T X_cF`` (``O(n_F^2 T)``) at every solve. The same
+        caution applies to ``FactorCovariance`` with many factors: a
+        diagonal-plus-low-rank solve only pays off while the rank stays well below
+        ``n`` -- at full rank the structured route is slower than the plain dense
+        matrix.
+
+    Note:
+        The covariance is built from the *centered* data; the raw Gram
+        ``X^T X`` is the second-moment matrix, which differs by the rank-one mean
+        correction ``T x_bar x_bar^T``. This backend centers for you.
+
+    Attributes:
+        returns: The ``(T, n)`` matrix of observations (e.g. asset returns).
+        ridge: A non-negative diagonal loading added to the covariance.
+
+    Examples:
+        >>> import numpy as np
+        >>> rng = np.random.default_rng(0)
+        >>> returns = rng.standard_normal((50, 4))
+        >>> gram = GramCovariance(returns)
+        >>> bool(np.allclose(gram.matvec(np.ones(4)), np.cov(returns, rowvar=False) @ np.ones(4)))
+        True
+    """
+
+    returns: NDArray[np.float64]
+    ridge: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate that ``returns`` is a ``(T, n)`` matrix with ``T >= 2`` and ``ridge >= 0``.
+
+        Raises:
+            ValueError: If ``returns`` is not two-dimensional with at least two
+                rows, or if ``ridge`` is negative.
+        """
+        if self.returns.ndim != 2 or self.returns.shape[0] < 2:
+            msg = f"returns must be a (T, n) matrix with T >= 2 observations, got shape {self.returns.shape}"
+            raise ValueError(msg)
+        if self.ridge < 0.0:
+            msg = f"ridge must be non-negative, got {self.ridge}"
+            raise ValueError(msg)
+
+    @cached_property
+    def _centered(self) -> NDArray[np.float64]:
+        """The column-centered data matrix ``X_c`` of shape ``(T, n)``."""
+        return cast("NDArray[np.float64]", self.returns - self.returns.mean(axis=0, keepdims=True))
+
+    @property
+    def _t(self) -> int:
+        """Number of observations ``T``."""
+        return int(self.returns.shape[0])
+
+    @property
+    def _scale(self) -> float:
+        """The sample-covariance scale ``1 / (T - 1)`` (``ddof = 1``, matching ``np.cov``)."""
+        return 1.0 / (self._t - 1)
+
+    @property
+    def n(self) -> int:
+        """Number of assets (the dimension of the covariance)."""
+        return int(self.returns.shape[1])
+
+    def matvec(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Compute ``Sigma @ x`` as ``scale * X_c^T (X_c @ x) + ridge * x``.
+
+        Args:
+            x: Vector of shape ``(n,)`` or matrix of shape ``(n, r)``.
+
+        Returns:
+            ``Sigma @ x`` with the same trailing shape as ``x``, in ``O(T n)`` per
+            column and without forming the ``n x n`` covariance.
+        """
+        xc = self._centered
+        product = self._scale * (xc.T @ (xc @ x))
+        return product + self.ridge * x
+
+    def cross(self, free: NDArray[np.bool_], x: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Compute the free-to-blocked cross product ``Sigma[free][:, ~free] @ x[~free]``.
+
+        The ridge is diagonal, so it contributes nothing to this off-diagonal
+        block; the result is ``scale * X_cF^T (X_cB @ x_B)``.
+
+        Args:
+            free: Boolean mask of shape ``(n,)`` selecting the free assets.
+            x: Full-length vector of shape ``(n,)``; only the blocked entries
+               ``x[~free]`` enter the product.
+
+        Returns:
+            Vector of shape ``(n_free,)``.
+        """
+        blocked = ~free
+        xc_free = self._centered[:, free]
+        xc_blocked = self._centered[:, blocked]
+        return self._scale * (xc_free.T @ (xc_blocked @ x[blocked]))
+
+    def solve_free(self, free: NDArray[np.bool_], rhs: NDArray[np.float64]) -> NDArray[np.float64]:
+        """Solve ``Sigma[free][:, free] @ y = rhs`` from the free columns of ``X_c``.
+
+        Without a ridge the free block ``scale * X_cF^T X_cF`` is formed and solved
+        directly (it is singular, and the solve unreliable, once the free set
+        outgrows the data rank -- which ``rcond_free`` reports so the CLA can
+        refuse). With a positive ridge the block is positive definite and, when
+        there are more free assets than observations, the solve is done by the
+        Woodbury identity in ``T``-space instead of inverting an ``n_F x n_F``
+        matrix.
+
+        Args:
+            free: Boolean mask of shape ``(n,)`` selecting the free assets.
+            rhs: Right-hand side of shape ``(n_free,)`` or ``(n_free, r)``.
+
+        Returns:
+            The solution ``y`` with the same shape as ``rhs``.
+        """
+        xc_free = self._centered[:, free]
+        n_free = xc_free.shape[1]
+
+        if self.ridge > 0.0 and self._t < n_free:
+            # Woodbury in the T-dimensional observation space:
+            # (ridge I + W^T W)^{-1} = (1/ridge) I - (1/ridge^2) W^T (I + W W^T / ridge)^{-1} W,
+            # with W = sqrt(scale) X_cF (shape (T, n_free)).
+            w = np.sqrt(self._scale) * xc_free
+            correction_system = np.eye(self._t) + (w @ w.T) / self.ridge
+            correction = w.T @ np.linalg.solve(correction_system, w @ rhs)
+            return cast("NDArray[np.float64]", (rhs - correction / self.ridge) / self.ridge)
+
+        block = self._scale * (xc_free.T @ xc_free)
+        if self.ridge > 0.0:
+            block = block + self.ridge * np.eye(n_free)
+        return cast("NDArray[np.float64]", np.linalg.solve(block, rhs))
+
+    def rcond_free(self, free: NDArray[np.bool_]) -> float:
+        """Reciprocal condition number of the free block, from the SVD of ``X_cF``.
+
+        The eigenvalues of ``scale * X_cF^T X_cF + ridge I`` are
+        ``scale * sigma_i^2 + ridge`` for the singular values ``sigma_i`` of
+        ``X_cF``, plus extra ``ridge`` eigenvalues when there are more free assets
+        than the rank of ``X_cF``. This reads the conditioning off the SVD of the
+        ``(T, n_free)`` data block without forming the ``n_F x n_F`` matrix, so a
+        rank-deficient (``T``-limited) free set correctly drives the result toward
+        zero.
+
+        Args:
+            free: Boolean mask of shape ``(n,)`` selecting the free assets.
+
+        Returns:
+            The reciprocal 2-norm condition number of the free block, in ``[0, 1]``.
+        """
+        n_free = int(np.count_nonzero(free))
+        if n_free == 0:
+            return 1.0
+        singular_values = np.linalg.svd(self._centered[:, free], compute_uv=False)
+        eig = self._scale * singular_values**2
+        lam_max = float(eig[0]) + self.ridge
+        if lam_max <= 0.0:
+            return 0.0
+        lam_min = self.ridge if n_free > singular_values.shape[0] else float(eig[-1]) + self.ridge
+        return max(lam_min, 0.0) / lam_max
+
+
 # Backward-compatible alias. The protocol was introduced as ``CovarianceOperator``
 # for the portfolio (covariance) setting; it is the Hessian contract for any
 # parametric active-set path, so the canonical name is now ``QuadraticForm``.

--- a/src/cvxcla/pathtracer.py
+++ b/src/cvxcla/pathtracer.py
@@ -1,0 +1,150 @@
+"""Generic parametric active-set path tracer.
+
+The Critical Line Algorithm is one instance of a broader scheme: the optimiser of
+a convex quadratic program is followed as a single scalar parameter ``lambda``
+varies, the solution path is piecewise linear, and it is traced exactly by
+stepping from one breakpoint to the next while maintaining a *coordinate* active
+set. The same scheme drives least angle regression (LARS) and the LASSO homotopy.
+
+This module factors out the part that is identical across those problems:
+
+* ``select_next_event`` -- the simplex-style "smallest positive ratio to the next
+  event" rule with a Bland lowest-index tie-break for anti-cycling. It works on an
+  ``(n, k)`` matrix of candidate critical ``lambda`` values, where the row is the
+  coordinate and the column is the (problem-defined) event type.
+* ``trace`` -- the control loop: build the first vertex, solve the current affine
+  segment, scan events, pick the next one, flip one coordinate's activity, repeat.
+
+Everything problem-specific (the segment solve, what an event *means*, how a vertex
+is recorded) lives behind the ``ParametricProblem`` protocol. ``CLA`` (portfolio
+frontier) and ``Lasso`` (regression path) are two implementations; both are driven
+by the same ``trace`` here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@runtime_checkable
+class ParametricProblem(Protocol):
+    """The problem-specific contract the generic ``trace`` loop drives.
+
+    A ``State`` describes the current vertex (which coordinates are free/blocked
+    and their values); a ``Segment`` describes the affine piece valid until the
+    next event. Both are opaque to the tracer: it only passes them back to the
+    problem. Implementations record vertices as they are discovered (the tracer
+    returns nothing).
+    """
+
+    @property
+    def tol(self) -> float:
+        """Tolerance for the event-selection tie-break and validity window."""
+        ...  # pragma: no cover
+
+    @property
+    def dimension(self) -> int:
+        """Number of coordinates ``n`` (sets the iteration safety cap)."""
+        ...  # pragma: no cover
+
+    def begin(self) -> tuple[float, Any]:
+        """Record the first vertex and return ``(lambda_start, initial_state)``."""
+        ...  # pragma: no cover
+
+    def segment(self, state: Any) -> Any:
+        """Solve the affine segment valid at ``state`` (the reduced KKT system)."""
+        ...  # pragma: no cover
+
+    def event_matrix(self, state: Any, segment: Any) -> NDArray[np.float64]:
+        """Return the ``(n, k)`` matrix of candidate critical ``lambda`` values.
+
+        Entry ``(i, j)`` is the ``lambda`` at which coordinate ``i`` would fire
+        event type ``j`` along ``segment``; ``-inf`` means "no such event".
+        """
+        ...  # pragma: no cover
+
+    def step(self, state: Any, segment: Any, sec: int, direction: int, lam: float) -> Any:
+        """Record the vertex at ``lam`` after flipping coordinate ``sec``'s activity.
+
+        ``direction`` is the winning event-matrix column; the implementation maps
+        it to the new activity (and, where relevant, the sign) of ``sec``. Returns
+        the next ``State``.
+        """
+        ...  # pragma: no cover
+
+    def finish(self, state: Any, segment: Any) -> None:
+        """Record the final ``lambda = 0`` vertex (the segment's intercept)."""
+        ...  # pragma: no cover
+
+
+def select_next_event(l_mat: NDArray[np.float64], lam: float, tol: float) -> tuple[int, int, float] | None:
+    """Pick the next breakpoint from the event matrix, or ``None`` to stop.
+
+    The current segment is valid only for ``lambda`` at or below the current value
+    (the path is traced with non-increasing ``lambda``), so ratios above it are
+    spurious crossings outside the segment and are discarded; if none remain the
+    trace is complete. Among events tied (within ``tol``) for the largest valid
+    ratio, a Bland-style lowest-``(coordinate, event type)`` rule makes the choice
+    deterministic and prevents cycling on degenerate problems.
+
+    Args:
+        l_mat: The ``(n, k)`` matrix of candidate critical ``lambda`` values.
+        lam: The current (upper) ``lambda`` bound on valid events.
+        tol: Tolerance for the validity window and the tie-break.
+
+    Returns:
+        ``(sec, direction, lam_next)`` for the chosen event, or ``None`` if no
+        valid event remains.
+    """
+    l_mat = l_mat.copy()  # do not mutate the caller's matrix
+    l_mat[l_mat > lam + tol] = -np.inf  # pragma: no mutate
+
+    lam_max = np.max(l_mat)
+    if lam_max < 0:  # pragma: no mutate
+        return None
+
+    tied = np.argwhere(l_mat >= lam_max - tol)  # pragma: no mutate
+    sec, direction = tied[0]
+    return int(sec), int(direction), float(l_mat[sec, direction])
+
+
+def trace(problem: ParametricProblem) -> None:
+    """Trace the full piecewise-linear solution path of ``problem``.
+
+    Mirrors the turning-point loop of the Critical Line Algorithm, but driven
+    entirely through the ``ParametricProblem`` interface so the same control flow
+    serves any coordinate-active-set parametric quadratic program.
+
+    Args:
+        problem: The problem to trace; its ``begin``/``segment``/``event_matrix``/
+            ``step``/``finish`` hooks record the discovered vertices.
+
+    Raises:
+        RuntimeError: If the event loop fails to terminate within the safety cap
+            (each step fixes the activity of at least one coordinate, so a correct
+            trace runs ``O(n)`` times; vastly exceeding this signals cycling).
+    """
+    lam, state = problem.begin()
+
+    # Safety bound: far above any valid path length; exceeding it means the event
+    # loop failed to terminate, so we fail loudly rather than hang.
+    max_iterations = 100 * (problem.dimension + 1)  # pragma: no mutate
+    iterations = 0  # pragma: no mutate
+
+    while True:  # pragma: no mutate
+        iterations += 1  # pragma: no mutate
+        if iterations > max_iterations:  # pragma: no mutate
+            msg = "path tracer failed to converge: too many iterations"  # pragma: no mutate
+            raise RuntimeError(msg)  # pragma: no mutate
+
+        segment = problem.segment(state)
+        event = select_next_event(problem.event_matrix(state, segment), lam, problem.tol)
+        if event is None:
+            problem.finish(state, segment)
+            return
+
+        sec, direction, lam = event
+        state = problem.step(state, segment, sec, direction, lam)

--- a/src/cvxcla/types.py
+++ b/src/cvxcla/types.py
@@ -1,16 +1,3 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
 """Type definitions and classes for the Critical Line Algorithm.
 
 This module defines the core data structures used in the Critical Line Algorithm:

--- a/tests/benchmarks/test_backend_scaling.py
+++ b/tests/benchmarks/test_backend_scaling.py
@@ -1,0 +1,97 @@
+"""Wall-clock benchmarks for the CLA covariance backends across problem shapes.
+
+These measure the claim that the matrix-free backends are a *memory* play whose
+*speed* depends entirely on the rank / observation count relative to ``n``:
+
+* ``sample-covariance`` group -- ``DenseCovariance`` vs ``GramCovariance`` on the
+  same sample-covariance problem, swept over ``T/n``. Both trace an identical
+  frontier (the covariances are equal), so the only difference is the per-solve
+  cost: dense slices a precomputed ``Sigma_FF`` while Gram re-forms it (or uses
+  Woodbury in ``T``-space when ``T < n_free``). Expectation: dense wins for
+  ``T >= n``; Gram catches up / wins only in the short-sample regime.
+
+* ``factor-model`` group -- ``DenseCovariance`` vs ``FactorCovariance`` on a
+  diagonal-plus-low-rank problem, swept over the factor count ``k``. Expectation:
+  the factor backend wins for small ``k`` and *loses* as ``k`` approaches ``n``
+  (a full-rank structured solve is more work than the plain dense matrix).
+
+Run with ``make benchmark`` (these are excluded from the normal test run).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cvxcla import CLA, DenseCovariance, FactorCovariance, GramCovariance
+
+
+def _long_only_problem(rng: np.random.Generator, n: int) -> dict:
+    """A long-only, fully-invested CLA problem of size ``n`` (covariance added by caller)."""
+    return {
+        "mean": rng.uniform(0.0, 1.0, n),
+        "lower_bounds": np.zeros(n),
+        "upper_bounds": np.ones(n),
+        "a": np.ones((1, n)),
+        "b": np.ones(1),
+    }
+
+
+# (T, n): a long sample, a square one, and a short sample (T < n).
+_SAMPLE_SHAPES = [(1500, 80), (120, 120), (30, 150)]
+
+
+@pytest.mark.benchmark(group="sample-covariance")
+@pytest.mark.parametrize(("t", "n"), _SAMPLE_SHAPES, ids=lambda v: f"{v}")
+@pytest.mark.parametrize("backend", ["dense", "gram"])
+def test_sample_covariance_backend(benchmark, backend: str, t: int, n: int) -> None:
+    """Trace the frontier from a sample covariance via the dense vs the Gram backend.
+
+    A ridge is added in the short-sample regime (``T < n``) so the otherwise
+    rank-deficient covariance is positive definite for both backends; the dense
+    reference uses exactly ``np.cov(returns) + ridge I``, which equals what
+    ``GramCovariance`` represents, so both trace the same frontier.
+    """
+    rng = np.random.default_rng(0)
+    returns = rng.standard_normal((t, n))
+    ridge = 0.0 if t >= n else 1e-2
+    problem = _long_only_problem(rng, n)
+
+    if backend == "dense":
+        sigma = np.cov(returns, rowvar=False) + ridge * np.eye(n)
+        covariance = DenseCovariance(sigma)
+    else:
+        covariance = GramCovariance(returns, ridge=ridge)
+
+    result = benchmark(lambda: CLA(covariance=covariance, **problem))
+    assert len(result) >= 2
+
+
+# (n, k): low rank, mid rank, and (near) full rank.
+_FACTOR_SHAPES = [(150, 3), (150, 40), (150, 150)]
+
+
+@pytest.mark.benchmark(group="factor-model")
+@pytest.mark.parametrize(("n", "k"), _FACTOR_SHAPES, ids=lambda v: f"{v}")
+@pytest.mark.parametrize("backend", ["dense", "factor"])
+def test_factor_model_backend(benchmark, backend: str, n: int, k: int) -> None:
+    """Trace the frontier of a factor model via the dense vs the Woodbury factor backend.
+
+    The dense reference materialises the same ``diag(d) + U Delta U^T`` matrix the
+    factor backend represents, so both trace the same frontier and only the
+    per-solve method differs.
+    """
+    rng = np.random.default_rng(0)
+    u = rng.standard_normal((n, k)) / np.sqrt(n)
+    delta = rng.uniform(0.5, 2.0, k) * n
+    d = rng.uniform(0.5, 5.0, n)
+    problem = _long_only_problem(rng, n)
+
+    if backend == "dense":
+        sigma = np.diag(d) + (u * delta) @ u.T
+        covariance = DenseCovariance(sigma)
+    else:
+        covariance = FactorCovariance(d=d, u=u, delta=delta)
+
+    result = benchmark(lambda: CLA(covariance=covariance, **problem))
+    assert len(result) >= 2

--- a/tests/test_cla.py
+++ b/tests/test_cla.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from cvxcla import CLA, FactorCovariance
+from cvxcla.pathtracer import select_next_event
 from cvxcla.types import TurningPoint
 
 
@@ -624,10 +625,10 @@ class TestCLAMutationHardening:
 class TestCLAInternals:
     """Unit tests for the extracted per-iteration helpers of the trace.
 
-    The turning-point loop of ``CLA.__post_init__`` delegates to four focused
-    helpers (``_active_set``, ``_solve_kkt``, ``_event_ratios``,
-    ``_select_next_event``). These tests exercise each in isolation on a small,
-    well-conditioned problem, asserting the contract the loop relies on.
+    The turning-point loop (``cvxcla.pathtracer.trace``) delegates to three
+    focused CLA helpers (``_active_set``, ``_solve_kkt``, ``_event_ratios``) plus
+    the generic ``select_next_event``. These tests exercise each in isolation on a
+    small, well-conditioned problem, asserting the contract the loop relies on.
     """
 
     @pytest.fixture
@@ -698,7 +699,7 @@ class TestCLAInternals:
         l_mat = np.full((cla.mean.size, 4), -np.inf)
         l_mat[3, 1] = 0.5
         l_mat[1, 0] = 0.5 + cla.tol / 2  # tied with [3, 1] to within tol
-        event = cla._select_next_event(l_mat, lam=np.inf)
+        event = select_next_event(l_mat, lam=np.inf, tol=cla.tol)
         assert event is not None
         secchg, dirchg, _ = event
         assert (secchg, dirchg) == (1, 0)
@@ -707,12 +708,12 @@ class TestCLAInternals:
         """When every ratio lies above the current lam window, the trace stops."""
         l_mat = np.full((cla.mean.size, 4), -np.inf)
         l_mat[0, 0] = 5.0  # above the window -> filtered out
-        assert cla._select_next_event(l_mat, lam=1.0) is None
+        assert select_next_event(l_mat, lam=1.0, tol=cla.tol) is None
 
     def test_select_next_event_does_not_mutate_input(self, cla):
         """Selection works on a copy, leaving the caller's matrix untouched."""
         l_mat = np.full((cla.mean.size, 4), -np.inf)
         l_mat[0, 0] = 5.0
         before = l_mat.copy()
-        cla._select_next_event(l_mat, lam=1.0)
+        select_next_event(l_mat, lam=1.0, tol=cla.tol)
         np.testing.assert_array_equal(l_mat, before)

--- a/tests/test_lasso.py
+++ b/tests/test_lasso.py
@@ -1,0 +1,151 @@
+"""Tests for the LASSO path traced by the generic parametric active-set tracer.
+
+The path is validated two independent ways: against the LASSO subgradient (KKT)
+optimality conditions, and against a from-scratch coordinate-descent solver. Both
+the enter and the leave event families are exercised.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import numpy as np
+import pytest
+
+from cvxcla.lasso import Breakpoint, Lasso
+
+
+def _coordinate_descent(x: np.ndarray, y: np.ndarray, lam: float, iters: int = 5000) -> np.ndarray:
+    """An independent LASSO solver (cyclic coordinate descent with soft-threshold)."""
+    n = x.shape[1]
+    beta = np.zeros(n)
+    col_sq = np.sum(x * x, axis=0)
+    r = y - x @ beta
+    for _ in range(iters):
+        max_change = 0.0
+        for j in range(n):
+            if col_sq[j] == 0.0:
+                continue
+            rho = x[:, j] @ r + col_sq[j] * beta[j]
+            new = np.sign(rho) * max(abs(rho) - lam, 0.0) / col_sq[j]
+            if new != beta[j]:
+                r += x[:, j] * (beta[j] - new)
+                max_change = max(max_change, abs(new - beta[j]))
+                beta[j] = new
+        if max_change < 1e-12:
+            break
+    return beta
+
+
+def _kkt_violation(x: np.ndarray, y: np.ndarray, beta: np.ndarray, lam: float) -> float:
+    """Max subgradient-optimality violation of ``beta`` for LASSO at ``lam``."""
+    c = x.T @ (y - x @ beta)
+    viol = 0.0
+    for j in range(len(beta)):
+        if abs(beta[j]) > 1e-9:
+            viol = max(viol, abs(c[j] - lam * np.sign(beta[j])))
+        else:
+            viol = max(viol, max(0.0, abs(c[j]) - lam))
+    return float(viol)
+
+
+def _uncorrelated_problem():
+    """A generic design whose path only grows the support (enter events only)."""
+    rng = np.random.default_rng(0)
+    m, n = 40, 12
+    x = rng.standard_normal((m, n))
+    true_beta = np.zeros(n)
+    true_beta[[1, 4, 7]] = [2.0, -3.0, 1.5]
+    y = x @ true_beta + 0.1 * rng.standard_normal(m)
+    return x, y
+
+
+def _correlated_problem():
+    """A correlated design whose support oscillates (enter and leave events)."""
+    rng = np.random.default_rng(0)
+    m, n = 30, 8
+    f = rng.standard_normal((m, 2))
+    loadings = rng.standard_normal((2, n))
+    x = f @ loadings + 0.3 * rng.standard_normal((m, n))
+    true_beta = np.zeros(n)
+    true_beta[[0, 3]] = [3.0, -2.0]
+    y = x @ true_beta + 0.1 * rng.standard_normal(m)
+    return x, y
+
+
+class TestLassoPath:
+    """End-to-end correctness of the traced LASSO path."""
+
+    def test_endpoints(self):
+        """The path starts at (lam_max, 0) and ends at (0, OLS-on-support)."""
+        x, y = _uncorrelated_problem()
+        lasso = Lasso(x, y)
+        first, last = lasso.path[0], lasso.path[-1]
+        assert np.isclose(first.lam, lasso.lam_max)
+        np.testing.assert_allclose(first.beta, 0.0)
+        assert last.lam == 0.0
+
+    def test_path_matches_kkt_and_coordinate_descent(self):
+        """Sampled along the path, beta satisfies KKT and matches coordinate descent."""
+        x, y = _uncorrelated_problem()
+        lasso = Lasso(x, y)
+        for frac in (0.9, 0.7, 0.5, 0.3, 0.15, 0.05):
+            lam = frac * lasso.lam_max
+            beta = lasso.solution(lam)
+            assert _kkt_violation(x, y, beta, lam) < 1e-7
+            np.testing.assert_allclose(beta, _coordinate_descent(x, y, lam), atol=1e-5)
+
+    def test_leave_events_fire_and_path_stays_exact(self):
+        """A correlated design forces drop (leave) events; the path remains exact."""
+        x, y = _correlated_problem()
+        lasso = Lasso(x, y)
+        sizes = [int(bp.active.sum()) for bp in lasso.path]
+        assert any(b < a for a, b in pairwise(sizes)), "expected at least one drop event"
+        for frac in (0.9, 0.6, 0.35, 0.1):
+            lam = frac * lasso.lam_max
+            beta = lasso.solution(lam)
+            assert _kkt_violation(x, y, beta, lam) < 1e-7
+            np.testing.assert_allclose(beta, _coordinate_descent(x, y, lam), atol=1e-5)
+
+    def test_solution_clamps_outside_range(self):
+        """Querying beyond lam_max returns 0; at or below 0 returns the final fit."""
+        x, y = _uncorrelated_problem()
+        lasso = Lasso(x, y)
+        np.testing.assert_allclose(lasso.solution(2.0 * lasso.lam_max), 0.0)
+        np.testing.assert_allclose(lasso.solution(-1.0), lasso.path[-1].beta)
+
+    def test_solution_at_breakpoint(self):
+        """Evaluating exactly at a stored breakpoint reproduces its coefficients."""
+        x, y = _uncorrelated_problem()
+        lasso = Lasso(x, y)
+        mid = lasso.path[len(lasso.path) // 2]
+        np.testing.assert_allclose(lasso.solution(mid.lam), mid.beta, atol=1e-12)
+
+    def test_lambda_non_increasing(self):
+        """Breakpoint lambdas are recorded in non-increasing order."""
+        x, y = _uncorrelated_problem()
+        lams = [bp.lam for bp in Lasso(x, y).path]
+        assert all(a >= b for a, b in pairwise(lams))
+
+
+class TestLassoValidation:
+    """Input validation on construction."""
+
+    def test_rejects_non_2d_design(self):
+        """A 1d design matrix is rejected."""
+        with pytest.raises(ValueError, match="2d design matrix"):
+            Lasso(np.ones(5), np.ones(5))
+
+    def test_rejects_mismatched_response_length(self):
+        """A response whose length does not match the rows of x is rejected."""
+        with pytest.raises(ValueError, match="y must have shape"):
+            Lasso(np.ones((5, 3)), np.ones(4))
+
+
+def test_breakpoint_is_frozen():
+    """Breakpoint is an immutable record."""
+    import dataclasses
+
+    bp = Breakpoint(lam=1.0, beta=np.zeros(2), active=np.zeros(2, dtype=bool))
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        bp.lam = 2.0

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -20,6 +20,7 @@ from cvxcla import (
     CovarianceOperator,
     DenseCovariance,
     FactorCovariance,
+    GramCovariance,
     IncrementalDenseCovariance,
 )
 
@@ -578,3 +579,129 @@ class TestFactorLargeScale:
         assert len(cla) > 2
         dense_sigma_bytes = 8 * n * n
         assert peak < 0.03 * dense_sigma_bytes
+
+
+def _dense_from_returns(returns, ridge=0.0):
+    """The dense covariance a GramCovariance(returns, ridge) must reproduce."""
+    sigma = np.cov(returns, rowvar=False)
+    if ridge:
+        sigma = sigma + ridge * np.eye(returns.shape[1])
+    return DenseCovariance(sigma)
+
+
+class TestGramCovariance:
+    """Tests for the data-matrix (Gram) backend.
+
+    GramCovariance(returns, ridge) must behave exactly like
+    DenseCovariance(np.cov(returns, rowvar=False) + ridge I), while never forming
+    the n x n matrix. We check every protocol operation against that dense
+    reference across the long-sample (T >= n) and short-sample (T < n) regimes.
+    """
+
+    def test_is_quadratic_form_instance(self):
+        """GramCovariance satisfies the QuadraticForm (alias CovarianceOperator) protocol."""
+        gram = GramCovariance(np.random.default_rng(0).standard_normal((20, 4)))
+        assert isinstance(gram, CovarianceOperator)
+        assert gram.n == 4
+
+    def test_matches_numpy_cov(self):
+        """The (centered, ddof=1) covariance equals np.cov, not the raw second moment."""
+        returns = np.random.default_rng(1).standard_normal((40, 5))
+        gram = GramCovariance(returns)
+        sigma = np.cov(returns, rowvar=False)
+        v = np.arange(1.0, 6.0)
+        np.testing.assert_allclose(gram.matvec(v), sigma @ v)
+        # the raw (uncentered) second moment differs unless the data is mean-zero
+        raw = returns.T @ returns / (returns.shape[0] - 1)
+        assert not np.allclose(sigma, raw)
+
+    @pytest.mark.parametrize(("t", "n", "ridge"), [(40, 5, 0.0), (40, 5, 0.3), (4, 8, 0.5)])
+    def test_operations_match_dense(self, t, n, ridge):
+        """Every operation (matvec / cross / solve_free / rcond_free) agrees with the dense reference.
+
+        Covers the long-sample dense solve (T >= n), the ridged dense solve, and
+        the short-sample Woodbury solve (T < n, n_free > T).
+        """
+        rng = np.random.default_rng(int(t * 100 + n))
+        returns = rng.standard_normal((t, n))
+        gram = GramCovariance(returns, ridge=ridge)
+        dense = _dense_from_returns(returns, ridge=ridge)
+
+        free = np.array([i % 2 == 0 for i in range(n)])
+        free[0] = True  # ensure a non-empty, mixed mask
+
+        x = rng.standard_normal(n)
+        np.testing.assert_allclose(gram.matvec(x), dense.matvec(x), atol=1e-10)
+        np.testing.assert_allclose(gram.cross(free, x), dense.cross(free, x), atol=1e-10)
+
+        # single- and multi-RHS solves against the free block
+        rhs = rng.standard_normal(int(free.sum()))
+        if ridge > 0.0 or int(free.sum()) <= t:  # solvable block
+            np.testing.assert_allclose(gram.solve_free(free, rhs), dense.solve_free(free, rhs), atol=1e-8)
+            rhs2 = rng.standard_normal((int(free.sum()), 3))
+            np.testing.assert_allclose(gram.solve_free(free, rhs2), dense.solve_free(free, rhs2), atol=1e-8)
+
+        np.testing.assert_allclose(gram.rcond_free(free), dense.rcond_free(free), rtol=1e-6, atol=1e-12)
+
+    def test_woodbury_path_for_all_free_short_sample(self):
+        """With T < n_free and a ridge, the all-free solve uses Woodbury yet matches dense."""
+        rng = np.random.default_rng(7)
+        returns = rng.standard_normal((5, 12))
+        gram = GramCovariance(returns, ridge=0.2)
+        dense = _dense_from_returns(returns, ridge=0.2)
+        free = np.ones(12, dtype=bool)
+        rhs = rng.standard_normal(12)
+        np.testing.assert_allclose(gram.solve_free(free, rhs), dense.solve_free(free, rhs), atol=1e-8)
+
+    def test_rcond_empty_free_is_one(self):
+        """An empty free set is treated as perfectly conditioned."""
+        gram = GramCovariance(np.random.default_rng(0).standard_normal((10, 3)))
+        assert gram.rcond_free(np.zeros(3, dtype=bool)) == 1.0
+
+    def test_rcond_singular_free_block_is_zero(self):
+        """A constant (zero-variance) free column has a singular block: rcond = 0."""
+        returns = np.random.default_rng(0).standard_normal((6, 3))
+        returns[:, 0] = 2.5  # constant column -> centered to zero
+        gram = GramCovariance(returns)  # no ridge
+        assert gram.rcond_free(np.array([True, False, False])) == 0.0
+
+    def test_rank_deficient_free_block_drives_rcond_to_zero(self):
+        """Without a ridge, a free set larger than the data rank is singular (rcond ~ 0)."""
+        returns = np.random.default_rng(0).standard_normal((4, 8))
+        gram = GramCovariance(returns)  # rank <= T-1 = 3 < 8
+        assert gram.rcond_free(np.ones(8, dtype=bool)) < 1e-12
+
+    def test_cla_matches_dense_backend(self):
+        """The CLA traces the same frontier from the data matrix as from np.cov."""
+        rng = np.random.default_rng(3)
+        t, n = 60, 6  # long sample -> full-rank, well-posed
+        returns = rng.standard_normal((t, n))
+        mean = rng.uniform(0.0, 1.0, n)
+        kwargs = {
+            "mean": mean,
+            "lower_bounds": np.zeros(n),
+            "upper_bounds": np.ones(n),
+            "a": np.ones((1, n)),
+            "b": np.ones(1),
+        }
+        cla_gram = CLA(covariance=GramCovariance(returns), **kwargs)
+        cla_dense = CLA(covariance=DenseCovariance(np.cov(returns, rowvar=False)), **kwargs)
+
+        assert len(cla_gram) == len(cla_dense)
+        for tp_g, tp_d in zip(cla_gram.turning_points, cla_dense.turning_points, strict=True):
+            np.testing.assert_allclose(tp_g.weights, tp_d.weights, atol=1e-6)
+
+    def test_rejects_non_2d_returns(self):
+        """A 1d returns array is rejected."""
+        with pytest.raises(ValueError, match=r"must be a \(T, n\) matrix"):
+            GramCovariance(np.ones(5))
+
+    def test_rejects_too_few_observations(self):
+        """A single observation cannot define a sample covariance."""
+        with pytest.raises(ValueError, match="T >= 2"):
+            GramCovariance(np.ones((1, 3)))
+
+    def test_rejects_negative_ridge(self):
+        """A negative ridge is rejected."""
+        with pytest.raises(ValueError, match="ridge must be non-negative"):
+            GramCovariance(np.random.default_rng(0).standard_normal((10, 3)), ridge=-0.1)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -705,3 +705,27 @@ class TestGramCovariance:
         """A negative ridge is rejected."""
         with pytest.raises(ValueError, match="ridge must be non-negative"):
             GramCovariance(np.random.default_rng(0).standard_normal((10, 3)), ridge=-0.1)
+
+    def test_solve_is_matrix_free_in_n(self):
+        """A short-sample free-block solve never allocates an n x n matrix.
+
+        With ``T << n`` and a ridge, ``solve_free`` over the whole universe goes
+        through the Woodbury identity in ``T``-space, so its peak allocation
+        scales with ``T n`` (the data), not ``n^2`` (a dense block). This is the
+        memory advantage that motivates the backend.
+        """
+        rng = np.random.default_rng(0)
+        n, t = 800, 30
+        gram = GramCovariance(rng.standard_normal((t, n)), ridge=1e-2)
+        free = np.ones(n, dtype=bool)
+        rhs = rng.standard_normal(n)
+        _ = gram._centered  # warm the cached data matrix; measure only the solve
+
+        tracemalloc.start()
+        gram.solve_free(free, rhs)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        # The solve allocates a few copies of the (T, n) data, never an n x n block.
+        assert peak < 4 * 8 * t * n
+        assert peak < 0.2 * 8 * n * n  # far below a single dense n x n matrix

--- a/tests/test_pathtracer.py
+++ b/tests/test_pathtracer.py
@@ -1,0 +1,148 @@
+"""Tests for the generic parametric active-set path tracer.
+
+These cover the problem-independent pieces directly: the Bland event selection
+(``select_next_event``) and the ``trace`` control loop, including its safety cap.
+A tiny in-test ``ParametricProblem`` exercises the loop without any portfolio or
+regression machinery.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cvxcla.pathtracer import ParametricProblem, select_next_event, trace
+
+
+class TestSelectNextEvent:
+    """Unit tests for the Bland min-ratio event selector."""
+
+    def test_picks_largest_valid_ratio(self):
+        """The event with the largest ratio at or below the current lam wins."""
+        l_mat = np.full((3, 2), -np.inf)
+        l_mat[0, 0] = 0.2
+        l_mat[2, 1] = 0.9
+        assert select_next_event(l_mat, lam=np.inf, tol=1e-9) == (2, 1, 0.9)
+
+    def test_filters_ratios_above_current_lam(self):
+        """Ratios above the current lam window are spurious and discarded."""
+        l_mat = np.full((2, 2), -np.inf)
+        l_mat[0, 0] = 5.0  # above the window
+        l_mat[1, 1] = 0.4
+        assert select_next_event(l_mat, lam=1.0, tol=1e-9) == (1, 1, 0.4)
+
+    def test_bland_lowest_index_tiebreak(self):
+        """Among ratios tied within tol, the lowest (row, col) index wins."""
+        tol = 1e-5
+        l_mat = np.full((4, 4), -np.inf)
+        l_mat[3, 1] = 0.5
+        l_mat[1, 0] = 0.5 + tol / 2  # tied with [3, 1] to within tol
+        assert select_next_event(l_mat, lam=np.inf, tol=tol)[:2] == (1, 0)
+
+    def test_returns_none_when_no_valid_event(self):
+        """When every ratio lies above the lam window, the trace stops."""
+        l_mat = np.full((2, 2), -np.inf)
+        l_mat[0, 0] = 5.0
+        assert select_next_event(l_mat, lam=1.0, tol=1e-9) is None
+
+    def test_returns_none_when_all_neg_inf(self):
+        """An all -inf matrix means no candidate events remain."""
+        assert select_next_event(np.full((3, 2), -np.inf), lam=np.inf, tol=1e-9) is None
+
+    def test_does_not_mutate_input(self):
+        """Selection works on a copy, leaving the caller's matrix untouched."""
+        l_mat = np.full((2, 2), -np.inf)
+        l_mat[0, 0] = 5.0
+        before = l_mat.copy()
+        select_next_event(l_mat, lam=1.0, tol=1e-9)
+        np.testing.assert_array_equal(l_mat, before)
+
+
+class _CountdownProblem:
+    """A trivial 1-coordinate problem: step lam down a fixed schedule, then stop.
+
+    It records the lambdas the tracer drives it through. Used only to exercise the
+    generic loop end to end without any real linear algebra.
+    """
+
+    def __init__(self, schedule: list[float], tol: float = 1e-9) -> None:
+        self._schedule = schedule
+        self._i = 0
+        self.tol = tol
+        self.dimension = 1
+        self.visited: list[float] = []
+        self.finished_at: float | None = None
+
+    def begin(self) -> tuple[float, Any]:
+        """Start above the schedule with an empty state."""
+        self.visited.append(np.inf)
+        return np.inf, None
+
+    def segment(self, state: Any) -> Any:
+        """No segment data is needed for this toy problem."""
+        return None
+
+    def event_matrix(self, state: Any, segment: Any) -> np.ndarray:
+        """Emit the next scheduled lambda as the sole candidate event, else stop."""
+        if self._i < len(self._schedule):
+            return np.array([[self._schedule[self._i]]])
+        return np.array([[-np.inf]])
+
+    def step(self, state: Any, segment: Any, sec: int, direction: int, lam: float) -> Any:
+        """Advance the schedule and record the visited lambda."""
+        self.visited.append(lam)
+        self._i += 1
+        return None
+
+    def finish(self, state: Any, segment: Any) -> None:
+        """Record where the trace terminated."""
+        self.finished_at = 0.0
+
+
+class _NeverConvergesProblem:
+    """A problem that always offers the same event, so the loop never terminates."""
+
+    def __init__(self, n: int) -> None:
+        self.tol = 1e-9
+        self.dimension = n
+
+    def begin(self) -> tuple[float, Any]:
+        """Start at +inf."""
+        return np.inf, None
+
+    def segment(self, state: Any) -> Any:
+        """No segment data needed."""
+        return None
+
+    def event_matrix(self, state: Any, segment: Any) -> np.ndarray:
+        """Always return a fixed, in-window event so the loop cannot finish."""
+        return np.array([[1.0]])
+
+    def step(self, state: Any, segment: Any, sec: int, direction: int, lam: float) -> Any:
+        """No state change, guaranteeing non-termination."""
+        return None
+
+    def finish(self, state: Any, segment: Any) -> None:  # pragma: no cover - never reached
+        """Never called: the loop raises before converging."""
+
+
+def test_trace_visits_schedule_and_finishes():
+    """Trace drives the problem down its event schedule, then calls finish."""
+    problem = _CountdownProblem([0.8, 0.5, 0.2])
+    trace(problem)
+    assert problem.visited == [np.inf, 0.8, 0.5, 0.2]
+    assert problem.finished_at == 0.0
+
+
+def test_trace_raises_when_loop_does_not_terminate():
+    """The safety cap turns non-termination into a clear RuntimeError."""
+    with pytest.raises(RuntimeError, match="failed to converge"):
+        trace(_NeverConvergesProblem(n=2))
+
+
+def test_problems_are_recognised_as_parametric_problems():
+    """The toy problems structurally satisfy the runtime-checkable protocol."""
+    assert isinstance(_CountdownProblem([0.5]), ParametricProblem)
+    assert isinstance(_NeverConvergesProblem(n=1), ParametricProblem)


### PR DESCRIPTION
## What

The Critical Line Algorithm is one instance of a *parametric active-set path-tracer* — the family that also contains LARS and the LASSO homotopy (see the paper's `sec:lars`). This PR factors the problem-independent machinery out of the portfolio code so a second problem reuses it **verbatim**, proving the generalization in the package rather than on paper.

## Changes

- **`pathtracer.py` (new)** — the generic `trace` loop and the Bland min-ratio `select_next_event`, behind a `ParametricProblem` protocol. `CLA`'s turning-point loop now delegates to it; its tested helpers (`_active_set`, `_solve_kkt`, `_event_ratios`) are unchanged.
- **`operators.py`** — rename the `CovarianceOperator` protocol to **`QuadraticForm`** (the Hessian contract for any such path), keeping `CovarianceOperator` as a backward-compatible alias. `H = Σ` for the CLA, `H = XᵀX` for a regression path — the same operator, the same `DenseCovariance`/`FactorCovariance` backends.
- **`lasso.py` (new)** — a `Lasso` problem implementing the same protocol, traced by the same loop. Validated two independent ways: the LASSO subgradient (KKT) optimality conditions and a from-scratch coordinate-descent solver; both **enter** and **leave** events are exercised (the full homotopy, not just forward LARS).

## Compatibility

`CLA`'s behaviour and public API are unchanged (`from cvxcla import CovarianceOperator` still works). The pre-existing CLA/operator tests pass untouched except for 3 that called the moved `select_next_event`.

## Housekeeping

- Drop the leftover Apache per-file license headers (from the upstream Stanford origin).
- Align the stale Apache license metadata — README badge, README text, `pyproject.toml` `license`/classifier — to the repository's actual **MIT** `LICENSE` file.

## Checks

180 tests, **100% coverage**; `mypy --strict`, `ty`, `ruff`, `interrogate`, and `make validate` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)