### PR TITLE
docs(paper): note why slack variables do not extend the CLA to inequalities

### DIFF
--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -1143,7 +1143,14 @@ set partitions the \emph{variables} into free and box-blocked, never a set of
 general inequality rows, so the reduced system is always a principal submatrix of
 $\Sig$ (\S\ref{sec:operators}) rather than a bordered KKT system. That restriction
 is exactly what keeps each step a single symmetric positive-definite solve, and it
-is the portfolio structure the method exploits.
+is the portfolio structure the method exploits. The natural reflex of turning an
+inequality $A w \ge b$ into an equality $A w - s = b$ with a slack $s \ge 0$ does
+not recover this structure: the slack carries no curvature in the objective, so the
+augmented Hessian $\operatorname{diag}(\Sig, 0)$ is only positive \emph{semi}-definite,
+and the reduced solve is singular whenever a slack is free (which is precisely when
+its inequality is inactive). Admitting general inequalities therefore requires the
+bordered KKT system above and an event for each row activating or releasing, not a
+change of variables.
 
 The LASSO solves, for a response $y$ and design matrix $X$,
 \[


### PR DESCRIPTION
A one-paragraph addition to §11 (the mpQP/LARS connection), where the paper already explains that the CLA handles box bounds but not general inequality *rows*.

Readers will reach for the obvious move — turn `Aw ≥ b` into `Aw − s = b, s ≥ 0` — so the paper now says why it fails: the slack has no curvature in the objective, the augmented Hessian `diag(Σ, 0)` is only positive **semi**-definite, and the reduced KKT solve is singular whenever a slack is free (i.e. whenever its inequality is inactive). General inequalities require the bordered KKT system and a per-row activation/release event, not a change of variables.

Closes the gap between "the CLA does not attempt arbitrary polyhedral constraints" and *why the easy workaround doesn't help*.

Builds clean (two pdflatex passes), no undefined citations, no em-dashes.