### PR TITLE
docs(paper): sharpen the Bailey-Lopez de Prado comparison (KKT distinction; drop praise)

### DIFF
--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -650,10 +650,9 @@ large instances can still defeat the floating-point event logic.
 The most widely used open implementation of the CLA is that of
 \citet{bailey2013} (the algorithm behind PyPortfolioOpt's \texttt{CLA}
 \citep{pyportfolioopt}, against which we benchmark in \S\ref{sec:experiment}).
-That paper deserves credit as the reference open-source CLA: a careful,
-step-by-step exposition that, when published, filled a real gap (the only
-prior documented implementation was the Markowitz--Todd VBA-Excel code of
-\citet{markowitz2000}), and it remains the pedagogical standard. Our
+That paper is the reference open-source CLA; when published it filled a real gap,
+as the only prior documented implementation was the Markowitz--Todd VBA-Excel code
+of \citet{markowitz2000}. Our
 implementation in fact shares several of its design choices: the same greedy
 first turning point (\S\ref{sec:first}), the explicit minimum-variance endpoint
 at $\lambda = 0$, and a one-dimensional search between bracketing turning points
@@ -679,7 +678,14 @@ single multi-right-hand-side solve against $\Sig_{\F\F}$ feeds an $m \times m$
 Schur complement \eqref{eq:schur} that handles the equality constraints, and the
 event search over all candidates is vectorised rather than looped. The $\alpha$
 and $\beta$ systems reuse the same factorisation, and the covariance enters only
-as a black-box solve, which is what makes the backend abstraction possible.
+as a black-box solve, which is what makes the backend abstraction possible. More
+fundamentally, Bailey--L\'opez de Prado never assemble a KKT system at all: they
+invert $\Sig_{\F\F}$ explicitly and substitute the inverse into closed-form
+Lagrange expressions for $\lambda$, $\gamma$, and $w_\F$ that are specialised to
+the single budget row. Casting each step instead as a reduced KKT saddle-point
+solve, with the equality constraints carried by the $m \times m$ Schur complement
+\eqref{eq:schur}, is precisely what lets \texttt{cvxcla} take an arbitrary $A$
+(next point) where their closed-form algebra admits only one.
 
 \item \textbf{Constraint generality.} The reference implementation targets box
 bounds plus a single budget (fully-invested) constraint. \texttt{cvxcla} admits


### PR DESCRIPTION
Two edits to §6 (the Bailey–López de Prado comparison), grounded in a re-read of the source paper (Bailey & López de Prado 2013).

1. **Explicit KKT-vs-closed-form distinction.** Their algorithm never assembles a KKT system: it inverts `Σ_FF` explicitly and substitutes the inverse into closed-form Lagrange expressions for λ, γ, and `w_F` that are *specialised to the single budget row*. Casting each step instead as a reduced KKT saddle-point solve, with the equalities carried by the `m×m` Schur complement, is precisely what lets `cvxcla` take an arbitrary `A` where their algebra admits only one. This is the cleanest one-line explanation of *why* we generalise to `m>1` and they don't (previously only implicit in "block elimination" vs "explicit inverse").

2. **Drop the praise.** Removed "deserves credit", "careful, step-by-step exposition", and "remains the pedagogical standard". Kept the factual context: it is the reference open-source CLA that filled the gap left by the Markowitz–Todd VBA-Excel code.

Builds clean (two pdflatex passes), no undefined citations, no em-dashes.