### PR TITLE
docs: reproduce the S&P 500 example from a frozen committed snapshot

### DIFF
--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -1057,11 +1057,18 @@ optima rather than approximating them (\srcfile{experiments/validate_exact.py}{e
 \subsection{Empirical example: the S\&P 500 frontier}
 \label{sec:empirical}
 
-To close, we run the algorithm on real data. Using
-\srcfile{experiments/fetch_sp500.py}{experiments/fetch\_sp500.py} we pull the current S\&P 500 constituents
-from Wikipedia and download five years of daily adjusted-close prices via
-\texttt{yfinance}, yielding $N = 494$ assets over $T = 1213$ trading days
-(2021-07-30 to 2026-05-29) after dropping thinly-traded names. From the
+To close, we run the algorithm on real data. The experiment runs off a frozen
+snapshot shipped with the package,
+\srcfile{experiments/data/sp500_pct_returns.parquet}{experiments/data/sp500\_pct\_returns.parquet}
+($N = 494$ assets over $T = 1213$ trading days, 2021-07-30 to 2026-05-29;
+SHA-256 \texttt{b5faa522\ldots9937e}), so the figures below reproduce
+deterministically and offline, with no dependence on a live data feed. The
+snapshot was produced once by
+\srcfile{experiments/fetch_sp500.py}{experiments/fetch\_sp500.py}, which pulls the
+then-current S\&P 500 constituents from Wikipedia, downloads five years of daily
+adjusted-close prices via \texttt{yfinance}, and drops thinly-traded names; that
+script is retained for provenance and refresh only and is not part of the
+reproducible path. From the
 full-history sample mean and covariance (condition number $\approx 1.1\times
 10^{5}$) the CLA traces the entire long-only frontier (\textbf{96 turning
 points}) in a median of $\approx 14$~ms (Figure~\ref{fig:realfrontier}); a

--- a/experiments/fetch_sp500.py
+++ b/experiments/fetch_sp500.py
@@ -3,9 +3,15 @@
 Pulls the current S&P 500 ticker list from Wikipedia, downloads ~5 years of
 adjusted-close prices through yfinance, cleans thinly-traded / late-listed names,
 and saves the daily percentage-return matrix to
-``experiments/data/sp500_pct_returns.parquet``. The CLA real-data experiment
-(``experiments/frontier_real.py``) reads that file, so the network fetch only
-needs to run once.
+``experiments/data/sp500_pct_returns.parquet``.
+
+This is a *provenance* script, not part of the reproducible path: a frozen
+snapshot is already committed to the repository, and the paper's experiments
+(``frontier_real.py``, ``validate_exact.py``) read that committed file directly.
+Run this only to refresh the snapshot from live sources, which will produce a
+*different* dataset (constituents and prices drift over time). The committed
+snapshot is N=494 assets x T=1213 days (2021-07-30 to 2026-05-29),
+SHA-256 b5faa5222555f28d77bad5404565297bb25bbe92b0b813f416cd2bebac79937e.
 
 Usage:
     uv run python experiments/fetch_sp500.py

--- a/experiments/frontier_real.py
+++ b/experiments/frontier_real.py
@@ -1,6 +1,7 @@
 """Empirical CLA experiment on real S&P 500 returns.
 
-Loads the daily-return matrix produced by ``experiments/fetch_sp500.py`` and:
+Loads the frozen daily-return matrix committed at
+``experiments/data/sp500_pct_returns.parquet`` and:
 
 1. traces the entire long-only efficient frontier of the full universe from the
    full-history sample covariance (the dense backend), and times a rank-K
@@ -10,8 +11,11 @@ Loads the daily-return matrix produced by ``experiments/fetch_sp500.py`` and:
 
 Writes the real-data frontier figure to ``docs/paper/real_frontier.pdf``.
 
+The return matrix is a frozen snapshot committed to the repository, so this
+experiment reproduces deterministically and offline. ``experiments/fetch_sp500.py``
+is only needed to refresh that snapshot from live sources, not to run this script.
+
 Usage:
-    uv run python experiments/fetch_sp500.py    # once, to download the data
     uv run python experiments/frontier_real.py
 """
 

--- a/experiments/validate_exact.py
+++ b/experiments/validate_exact.py
@@ -18,8 +18,11 @@ trace the frontier with the CLA, then at the midpoint lambda of every segment we
 and report the maximum weight discrepancy. Agreement to solver tolerance
 confirms the CLA segments are the true optimisers, not an approximation.
 
+The return matrix is a frozen snapshot committed at
+``experiments/data/sp500_pct_returns.parquet``, so this check reproduces offline;
+``experiments/fetch_sp500.py`` is only for refreshing that snapshot.
+
 Usage:
-    uv run python experiments/fetch_sp500.py    # once, to download the data
     uv run python experiments/validate_exact.py
 """
 


### PR DESCRIPTION
Closes #721.

## Summary

Addresses JSS referee point M3: §10.6 read as a live Wikipedia + `yfinance` fetch, which cannot be reproduced deterministically (constituents and prices drift over time). In fact the reproducible scripts (`frontier_real.py`, `validate_exact.py`) already load a **frozen snapshot committed** at `experiments/data/sp500_pct_returns.parquet`; only `fetch_sp500.py` touches the network. This PR makes that explicit and pins the snapshot.

## Changes

- **Paper §10.6** — states the experiment runs off the committed snapshot (`N=494`, `T=1213`, 2021-07-30 → 2026-05-29, **SHA-256 `b5faa522…9937e`**) and reproduces offline; `fetch_sp500.py` is demoted to provenance/refresh only, explicitly outside the reproducible path.
- **`frontier_real.py` / `validate_exact.py`** — removed the misleading "run `fetch_sp500.py` once to download the data" usage note; the snapshot is committed, so they run offline. Usage now lists only the experiment command.
- **`fetch_sp500.py`** — documented as provenance-only; notes that refreshing produces a *different* dataset, and records the committed snapshot's shape and SHA-256.

The data file itself was already committed (5.8 MB parquet, tracked, not gitignored); verified its shape/date-range/checksum match the paper.

## Verification

- Paper builds (tectonic), 0 undefined references.
- Confirmed the committed parquet loads to `(1213, 494)`, dates 2021-07-30 → 2026-05-29, SHA-256 `b5faa5222555f28d77bad5404565297bb25bbe92b0b813f416cd2bebac79937e`.
- Pre-commit hooks (ruff, interrogate, secrets) pass.

## Note

A permanent external archive (Zenodo DOI) for the dataset + package is tracked separately in #723; this PR pins the in-repo snapshot by checksum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)