### PR TITLE
docs(paper): call Bailey-López de Prado an implementation, not an algorithm

### DIFF
--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -735,11 +735,11 @@ worst-case turning-point count, is combinatorial, so sufficiently tie-heavy or
 large instances can still defeat the floating-point event logic.
 \end{itemize}
 
-\section{Relation to the Bailey--L\'opez de Prado algorithm}
+\section{Relation to the Bailey--L\'opez de Prado implementation}
 \label{sec:bailey}
 
 The most widely used open implementation of the CLA is that of
-\citet{bailey2013} (the algorithm behind PyPortfolioOpt's \texttt{CLA}
+\citet{bailey2013} (the implementation behind PyPortfolioOpt's \texttt{CLA}
 \citep{pyportfolioopt}, against which we benchmark in \S\ref{sec:experiment}).
 That paper is the reference open-source CLA; when published it filled a real gap,
 as the only prior documented implementation was the Markowitz--Todd VBA-Excel code


### PR DESCRIPTION
Bailey and López de Prado published an open-source **implementation** of Markowitz's Critical Line Algorithm, not a new algorithm. Renames the two places the paper called it one:

- **§7 section title:** "Relation to the Bailey–López de Prado algorithm" → "… implementation"
- "the **algorithm** behind PyPortfolioOpt's CLA" → "the **implementation** behind PyPortfolioOpt's CLA"

The remaining mentions of `\citet{bailey2013}` are citations or refer correctly to Markowitz's CLA, so they are unchanged.

## Verification
- Paper builds (tectonic); section title and phrase render as "implementation"; 0 undefined references.

## Note
There is one adjacent phrase in §8.2 — "a widely-used implementation of the critical-line algorithm of `\citet{bailey2013}`" — that loosely attributes the CLA to BLdP. I left it here to avoid a conflict with the open PR #727 (which edits that same sentence). Happy to tighten it within #727 if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)