### PR TITLE
chore(make): add paper timing-benchmark targets with pinned BLAS threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,22 @@ COVERAGE_FAIL_UNDER ?= 100
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk
 
+##@ Paper benchmarks
+
+# Pin BLAS/OpenMP threads so the paper timings are deterministic and comparable
+# across runs (Apple Accelerate / OpenMP / MKL). Run on a quiesced machine
+# (AC power, other apps closed) for paper-grade numbers.
+BENCH_THREADS := VECLIB_MAXIMUM_THREADS=8 OMP_NUM_THREADS=8 OPENBLAS_NUM_THREADS=8 MKL_NUM_THREADS=8
+
+.PHONY: bench-rank bench-runtime bench
+
+bench-rank: ## Table 2 + Figure 3: trace time vs factor rank (cvxcla only, fast)
+	$(BENCH_THREADS) uv run --with matplotlib python experiments/rank_scaling.py
+
+bench-runtime: ## Table 1 + Figure 2: trace time vs problem size (incl. PyPortfolioOpt, ~15-20 min)
+	$(BENCH_THREADS) uv run --with matplotlib --with pyportfolioopt==1.6.0 python experiments/runtime_scaling.py
+
+bench: bench-rank bench-runtime ## Regenerate both paper timing tables and figures
+
 # Optional: developer-local extensions (not committed)
 -include local.mk


### PR DESCRIPTION
Adds repo-owned `make` targets to regenerate the paper's timing tables and figures with a deterministic, comparable thread configuration.

## Targets

| Target | Produces | Notes |
|---|---|---|
| `make bench-rank` | Table 2 + Figure 3 | `rank_scaling.py`, cvxcla only, fast |
| `make bench-runtime` | Table 1 + Figure 2 | `runtime_scaling.py`, incl. PyPortfolioOpt 1.6.0, ~15-20 min |
| `make bench` | both | |

`BENCH_THREADS` pins `VECLIB_MAXIMUM_THREADS` / `OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `MKL_NUM_THREADS = 8` (Apple Accelerate / OpenMP / MKL) so the timings are repeatable across runs. Run on a quiesced machine (AC power, other apps closed) for paper-grade numbers — measuring under load drifts the absolute times several-fold.

## Placement

Added in the **repo-owned** `Makefile` (header: *"can be edited without breaking template sync"*), above the `-include local.mk` hook — not in the template-managed `.rhiza/rhiza.mk`.

## Verification

- `make -n bench` expands to the thread-pinned commands; `make help` lists the new "Paper benchmarks" section.
- Pre-commit hooks pass (`Check Makefile targets`, `Update README with Makefile help output`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)