### PR TITLE
perf(cla): skip the per-turning-point degeneracy guard when the covariance is well conditioned

### DIFF
--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -19,6 +19,13 @@ from .operators import DenseCovariance, QuadraticForm
 from .pathtracer import trace
 from .types import Frontier, FrontierPoint, TurningPoint
 
+# A genuinely rank-deficient free block has a reciprocal condition number at
+# round-off level (~1e-16); a well-posed or merely near-degenerate block sits
+# many orders above it (>= ~1e-4 across the degeneracy sweep in
+# experiments/degeneracy_boundary.py). The 1e-12 cut sits in the wide gap between
+# the two and is the conventional numerical-singularity scale.
+_RCOND_FLOOR = 1e-12  # pragma: no mutate
+
 
 class _Segment(NamedTuple):
     """The affine critical-line segment valid at one turning point.
@@ -141,6 +148,29 @@ class CLA:
     def dimension(self) -> int:
         """Number of assets ``n`` (the problem dimension for the path tracer)."""
         return len(self.mean)
+
+    @cached_property
+    def _free_blocks_well_conditioned(self) -> bool:
+        """Whether every free-block solve along the trace is numerically safe.
+
+        Decided once, up front. By Cauchy's interlacing theorem every principal
+        submatrix of the symmetric PSD covariance is at least as well conditioned
+        as the whole matrix -- deleting rows/columns cannot decrease the smallest
+        eigenvalue nor increase the largest -- so the reciprocal condition number
+        of any free block is ``>=`` that of the full covariance. Hence if the full
+        covariance clears the singularity floor, no free block encountered along
+        the trace can be singular, and the per-turning-point conditioning guard in
+        :meth:`_emit` is provably never triggered. We then skip it, paying one
+        ``rcond`` evaluation here instead of one at every turning point (the latter
+        is a full eigendecomposition of the free block, as costly as the KKT solve,
+        so it otherwise dominates the trace).
+
+        When the full covariance is itself near-singular (for example a sample
+        covariance from fewer observations than assets) this is ``False`` and the
+        per-step guard in :meth:`_emit` runs unchanged, preserving the degeneracy
+        diagnosis exactly.
+        """
+        return self.covariance_operator.rcond_free(np.ones(self.dimension, dtype=bool)) >= _RCOND_FLOOR
 
     def __post_init__(self) -> None:
         """Initialize the CLA object and compute the efficient frontier.
@@ -585,33 +615,39 @@ class CLA:
         BLAS/LAPACK build, the conditioning is deterministic and portable, so the
         completed-vs-declined boundary is the same on every platform.
 
+        The per-turning-point conditioning check is skipped entirely when the full
+        covariance is well conditioned: by interlacing no free block can then be
+        singular, so the check is provably redundant (see
+        :attr:`_free_blocks_well_conditioned`). It runs only when the full
+        covariance is itself near-singular, which is exactly the regime that can
+        produce an untrustworthy free-block solve.
+
         Raises:
             ValueError: With a degeneracy-specific message when the free-asset
                 block is numerically singular (an unreliable solve); otherwise
                 propagates nothing.
         """
-        # A genuinely rank-deficient free block has a reciprocal condition number
-        # at round-off level (~1e-16); a well-posed or merely near-degenerate
-        # block sits many orders above it (>= ~1e-4 across the degeneracy sweep in
-        # experiments/degeneracy_boundary.py). The 1e-12 cut sits in the wide gap
-        # between the two and is the conventional numerical-singularity scale.
-        rcond_floor = 1e-12  # pragma: no mutate
-        rcond = self.covariance_operator.rcond_free(free)
-        if rcond < rcond_floor:
-            n_free = int(np.count_nonzero(free))
-            msg = (
-                f"Critical Line Algorithm hit a degeneracy at lambda={lamb:.4g} "
-                f"(free-set size {n_free}): the free-asset covariance block is "
-                f"numerically singular (reciprocal condition number {rcond:.2g}), "
-                "so its solve is unreliable and the turning point cannot be "
-                "trusted. The trace was stopped rather than risk silently "
-                "returning a suboptimal frontier. This happens when the free set "
-                "grows past the covariance rank (for example a sample covariance "
-                "from far fewer days than assets). Use a well-conditioned, "
-                "full-rank estimate (ample history), or a FactorCovariance backend "
-                "(diagonal-plus-low-rank), which is positive definite by construction."
-            )
-            raise ValueError(msg)
+        # When the full covariance clears the floor, interlacing guarantees every
+        # free block does too, so the per-step guard can never fire -- skip it and
+        # the costly per-step rcond. Only a near-singular full covariance needs the
+        # check, and there it runs exactly as before.
+        if not self._free_blocks_well_conditioned:
+            rcond = self.covariance_operator.rcond_free(free)
+            if rcond < _RCOND_FLOOR:
+                n_free = int(np.count_nonzero(free))
+                msg = (
+                    f"Critical Line Algorithm hit a degeneracy at lambda={lamb:.4g} "
+                    f"(free-set size {n_free}): the free-asset covariance block is "
+                    f"numerically singular (reciprocal condition number {rcond:.2g}), "
+                    "so its solve is unreliable and the turning point cannot be "
+                    "trusted. The trace was stopped rather than risk silently "
+                    "returning a suboptimal frontier. This happens when the free set "
+                    "grows past the covariance rank (for example a sample covariance "
+                    "from far fewer days than assets). Use a well-conditioned, "
+                    "full-rank estimate (ample history), or a FactorCovariance backend "
+                    "(diagonal-plus-low-rank), which is positive definite by construction."
+                )
+                raise ValueError(msg)
         # Full-rank regime: the box violation is sub-tolerance round-off in the
         # covariance's flat directions, so project the candidate back onto the
         # feasible set and let the trace continue.


### PR DESCRIPTION
## Summary

The per-turning-point degeneracy guard added in #693 runs a full symmetric eigendecomposition (`rcond_free`) of the free-asset block at **every** turning point. That is an O(n³) factorisation layered on top of each KKT solve, and it came to dominate the trace — on the paper's factor-model benchmark it was **~79% of the dense backend's runtime at n=640** (3652 ms total vs 785 ms with the guard removed). This is the slowdown relative to the pre-#693 experiments.

## Fix

By **Cauchy's interlacing theorem**, every principal submatrix of the symmetric PSD covariance is at least as well conditioned as the whole matrix (deleting rows/columns cannot decrease λ_min nor increase λ_max), so `rcond(free block) ≥ rcond(full covariance)`.

- A new cached `_free_blocks_well_conditioned` evaluates the full covariance's `rcond` **once**, up front.
- When it clears the 1e-12 singularity floor, no free block can be singular, so `_emit` skips the per-step conditioning check entirely.
- When the full covariance is itself near-singular (e.g. a T<n sample covariance), the per-step guard runs **unchanged**, so the degeneracy diagnosis is preserved exactly.

This is **behaviour-preserving**: no contract or tolerance change.

> Note: a feasibility-gated variant was tried first and rejected — a numerically singular free block (size 9 vs covariance rank 8) can produce a turning point feasible to both the box and the budget, so gating the guard on feasibility silently accepts an untrustworthy solve. The interlacing argument is sound because it bounds *every* free block, not just the emitted ones.

## Results (paper factor-model benchmark, 8 BLAS threads)

| backend, n=640 | before | after |
|---|--:|--:|
| dense | ~3652 ms | **785 ms** (4.6×) |
| factor | ~131 ms | **107 ms** (1.2×) |

The guard drops to <1% of runtime (one up-front `eigvalsh` of the full covariance instead of one per turning point).

## Tests

- All 228 tests pass, including `test_rank_deficient_covariance_raises_degeneracy` and `test_near_degenerate_trace_completes_via_projection`.
- **100% coverage** preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)