### PR TITLE
feat(cla): add a fluent ProblemBuilder convenience layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ approximation needed.
 ## ✨ Features
 
 - Efficient computation of the entire efficient frontier
+- Fluent builder API — `CLA.problem(mean, cov).long_only().budget().trace()` — as a
+  readable alternative to the explicit constructor
 - Box bounds on every weight, plus general linear **equality** constraints
   `Aw = b` (budget, dollar-neutral, sector/factor neutrality) and general linear
   **inequality** constraints `Gw ≤ h` (group or sector exposure caps)
@@ -176,6 +178,21 @@ print(f"First 3 weights: {max_sharpe_weights[:3]}")
 Maximum Sharpe ratio: 2.946979
 First 3 weights: [0.         0.         0.08509841]
 ```
+
+The same problem reads more declaratively through the fluent builder, reached via
+`CLA.problem(...)`. Each step maps onto one constructor argument, and the terminal
+`.trace()` returns the identical `CLA`:
+
+```python
+# Same fully-invested, long-only problem as above, assembled fluently.
+built = CLA.problem(mean, covariance).long_only().budget().trace()
+
+# Pure sugar over the constructor: it returns the identical frontier.
+assert built.frontier.max_sharpe[0] == cla.frontier.max_sharpe[0]
+```
+
+`.bounds`, `.equality`, and `.inequality` add general bounds and constraints, as in
+the examples below.
 
 For visualization, you can plot the efficient frontier:
 

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -960,6 +960,36 @@ max Sharpe: 2.4037
 weights: [0.    0.    0.704 0.296 0.    0.   ]
 \end{lstlisting}
 
+The constructor takes the problem in its raw matrix form, which is explicit but
+verbose for the common cases. The same problem can be assembled through a fluent
+builder, \texttt{CLA.problem(\ldots)}, whose named steps each map onto one
+constructor argument: \texttt{.long\_only()} sets the box bounds $0\le w\le\ub$,
+\texttt{.budget()} adds the fully-invested row $\sum_i w_i = 1$, and the terminal
+\texttt{.trace()} builds the \texttt{CLA} and runs the walk. The builder is pure
+sugar: it adds no modelling power and accepts only the same polyhedral pieces, so
+it returns the identical object and frontier (Listing~\ref{lst:builder}).
+\texttt{.bounds(lower, upper)}, \texttt{.equality(A, b)}, and
+\texttt{.inequality(G, h)} add the general bounds and constraints discussed below.
+
+\begin{lstlisting}[style=pyin,caption={The same problem assembled through the
+fluent builder; \texttt{.trace()} returns the identical \texttt{CLA}.},label={lst:builder}]
+from cvxcla import CLA
+
+cla = (
+    CLA.problem(mean, Sigma)   # same mean and covariance as above
+       .long_only()            # box bounds 0 <= w <= 1
+       .budget()               # fully invested: sum(w) = 1
+       .trace()                # build the CLA and trace the frontier
+)
+print("turning points:", len(cla.turning_points))
+print("max Sharpe:", round(cla.frontier.max_sharpe[0], 4))
+\end{lstlisting}
+
+\begin{lstlisting}[style=pyout]
+turning points: 7
+max Sharpe: 2.4037
+\end{lstlisting}
+
 Switching to a structured backend changes only the covariance argument: the
 turning-point loop is untouched, and because the factor backend represents the
 \emph{same} $\Sig$ it returns the identical frontier (\S\ref{sec:operators}),

--- a/src/cvxcla/__init__.py
+++ b/src/cvxcla/__init__.py
@@ -11,6 +11,7 @@ methods to compute and analyze the efficient frontier.
 
 import importlib.metadata
 
+from .builder import ProblemBuilder
 from .cla import CLA
 from .lasso import Lasso
 from .operators import (
@@ -32,6 +33,7 @@ __all__ = [
     "IncrementalDenseCovariance",
     "Lasso",
     "ParametricProblem",
+    "ProblemBuilder",
     "QuadraticForm",
     "trace",
 ]

--- a/src/cvxcla/builder.py
+++ b/src/cvxcla/builder.py
@@ -1,0 +1,236 @@
+"""Fluent builder for assembling a Critical Line Algorithm problem.
+
+A thin, chainable convenience layer over the explicit :class:`cvxcla.cla.CLA`
+constructor. It exists purely for readability: portfolio practitioners expect to
+say "long-only, fully invested" rather than to remember that the budget is
+encoded as ``a=np.ones((1, n)), b=np.ones(1)``. Every method maps one-to-one onto
+a constructor argument, so the builder adds no modelling power and imposes no
+expression algebra: it accepts the same polyhedral pieces the CLA already
+supports (a quadratic objective, box bounds, linear equalities ``A w = b``, and
+linear inequalities ``G w <= h``) and nothing else. Anything the explicit
+constructor cannot trace, the builder cannot express either.
+
+The terminal :meth:`ProblemBuilder.trace` builds the ``CLA`` and runs the full
+parametric trace, returning the solved object whose ``frontier`` and
+``turning_points`` describe the entire efficient frontier (not a single optimum,
+which is the distinction from a one-shot convex solver).
+
+Examples:
+    >>> import numpy as np
+    >>> from cvxcla import CLA
+    >>> rng = np.random.default_rng(0)
+    >>> mean = rng.uniform(0.0, 1.0, 4)
+    >>> covariance = np.eye(4)
+    >>> cla = CLA.problem(mean, covariance).long_only().budget().trace()
+    >>> len(cla) > 0
+    True
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .cla import CLA
+from .operators import QuadraticForm
+
+
+class ProblemBuilder:
+    """Chainable builder that assembles the polyhedral pieces of a CLA problem.
+
+    Construct one via :meth:`cvxcla.cla.CLA.problem`, chain the constraint
+    methods (each returns ``self``), and finish with :meth:`trace`. The builder
+    is a convenience over the explicit ``CLA(...)`` constructor and validates
+    shapes with actionable messages as pieces are added.
+
+    Attributes:
+        mean: Vector of expected returns, fixing the problem dimension ``n``.
+        covariance: The covariance, either a plain ``numpy`` array or a
+            ``QuadraticForm`` backend (e.g. ``FactorCovariance``), passed through
+            to ``CLA`` unchanged so the structured backends keep their advantage.
+    """
+
+    def __init__(self, mean: NDArray[np.float64], covariance: NDArray[np.float64] | QuadraticForm) -> None:
+        """Start a builder for an ``n``-asset problem.
+
+        Args:
+            mean: Vector of expected returns of length ``n``.
+            covariance: Covariance matrix or ``QuadraticForm`` backend.
+        """
+        self.mean = np.asarray(mean, dtype=np.float64)
+        self.covariance = covariance
+        self._lower: NDArray[np.float64] | None = None
+        self._upper: NDArray[np.float64] | None = None
+        self._a_blocks: list[NDArray[np.float64]] = []
+        self._b_blocks: list[NDArray[np.float64]] = []
+        self._g_blocks: list[NDArray[np.float64]] = []
+        self._h_blocks: list[NDArray[np.float64]] = []
+
+    @property
+    def _n(self) -> int:
+        """Number of assets ``n``, fixed by ``mean``."""
+        return int(self.mean.shape[0])
+
+    def _as_vector(self, value: float | NDArray[np.float64], name: str) -> NDArray[np.float64]:
+        """Broadcast a scalar or length-``n`` array to a length-``n`` vector.
+
+        Args:
+            value: A scalar (applied to every asset) or a length-``n`` array.
+            name: Argument name, used in the error message.
+
+        Returns:
+            A fresh length-``n`` float array.
+
+        Raises:
+            ValueError: If an array is passed whose length is not ``n``.
+        """
+        array = np.asarray(value, dtype=np.float64)
+        if array.ndim == 0:
+            return np.full(self._n, float(array))
+        if array.shape != (self._n,):
+            msg = f"{name} must be a scalar or a length-{self._n} vector, got shape {array.shape}"
+            raise ValueError(msg)
+        return array.astype(np.float64, copy=True)
+
+    def bounds(self, lower: float | NDArray[np.float64], upper: float | NDArray[np.float64]) -> ProblemBuilder:
+        """Set the box bounds ``lower <= w <= upper``.
+
+        Args:
+            lower: Lower bound, a scalar (same for every asset) or length-``n`` array.
+            upper: Upper bound, a scalar or length-``n`` array.
+
+        Returns:
+            ``self``, for chaining.
+        """
+        self._lower = self._as_vector(lower, "lower")
+        self._upper = self._as_vector(upper, "upper")
+        return self
+
+    def long_only(self, upper: float | NDArray[np.float64] = 1.0) -> ProblemBuilder:
+        """Set long-only box bounds ``0 <= w <= upper`` (``upper`` defaults to ``1``).
+
+        Args:
+            upper: Upper bound, a scalar or length-``n`` array; defaults to ``1.0``.
+
+        Returns:
+            ``self``, for chaining.
+        """
+        return self.bounds(0.0, upper)
+
+    def budget(self, total: float = 1.0) -> ProblemBuilder:
+        """Add the fully-invested budget constraint ``sum(w) = total``.
+
+        This is the canonical all-ones equality row; ``total=0`` gives a
+        dollar-neutral book. Equivalent to ``equality(np.ones(n), total)``.
+
+        Args:
+            total: The right-hand side of ``sum(w) = total``; defaults to ``1.0``.
+
+        Returns:
+            ``self``, for chaining.
+        """
+        return self.equality(np.ones(self._n), total)
+
+    def equality(self, a: NDArray[np.float64], b: float | NDArray[np.float64]) -> ProblemBuilder:
+        """Add one or more equality rows ``A w = b``.
+
+        Accepts a single row (a length-``n`` vector with a scalar right-hand side)
+        or a block of rows (an ``(m, n)`` matrix with a length-``m`` right-hand
+        side). Repeated calls accumulate rows, so a budget plus a sector-neutrality
+        block can be added separately.
+
+        Args:
+            a: A length-``n`` row vector or an ``(m, n)`` matrix.
+            b: The matching right-hand side: a scalar for a single row, or a
+                length-``m`` vector for a block.
+
+        Returns:
+            ``self``, for chaining.
+
+        Raises:
+            ValueError: If ``a`` does not have ``n`` columns, or ``b``'s length
+                does not match the number of rows of ``a``.
+        """
+        a_block = np.atleast_2d(np.asarray(a, dtype=np.float64))
+        b_block = np.atleast_1d(np.asarray(b, dtype=np.float64))
+        self._validate_rows(a_block, b_block, "equality", "b")
+        self._a_blocks.append(a_block)
+        self._b_blocks.append(b_block)
+        return self
+
+    def inequality(self, g: NDArray[np.float64], h: float | NDArray[np.float64]) -> ProblemBuilder:
+        """Add one or more inequality rows ``G w <= h``.
+
+        Like :meth:`equality` but for ``<=`` rows (e.g. a group- or
+        sector-exposure cap). A ``>=`` row is expressed by negating both ``g`` and
+        ``h``. Repeated calls accumulate rows.
+
+        Args:
+            g: A length-``n`` row vector or a ``(p, n)`` matrix.
+            h: The matching right-hand side: a scalar for a single row, or a
+                length-``p`` vector for a block.
+
+        Returns:
+            ``self``, for chaining.
+
+        Raises:
+            ValueError: If ``g`` does not have ``n`` columns, or ``h``'s length
+                does not match the number of rows of ``g``.
+        """
+        g_block = np.atleast_2d(np.asarray(g, dtype=np.float64))
+        h_block = np.atleast_1d(np.asarray(h, dtype=np.float64))
+        self._validate_rows(g_block, h_block, "inequality", "h")
+        self._g_blocks.append(g_block)
+        self._h_blocks.append(h_block)
+        return self
+
+    def _validate_rows(self, lhs: NDArray[np.float64], rhs: NDArray[np.float64], method: str, rhs_name: str) -> None:
+        """Check a constraint block has ``n`` columns and a matching right-hand side.
+
+        Args:
+            lhs: The ``(m, n)`` coefficient block.
+            rhs: The length-``m`` right-hand side.
+            method: The calling method name, used in error messages.
+            rhs_name: The right-hand-side argument name, used in error messages.
+
+        Raises:
+            ValueError: If the column count is not ``n`` or the lengths disagree.
+        """
+        if lhs.shape[1] != self._n:
+            msg = f"{method}: coefficient matrix must have {self._n} columns, got shape {lhs.shape}"
+            raise ValueError(msg)
+        if rhs.shape[0] != lhs.shape[0]:
+            msg = f"{method}: {rhs_name} must have {lhs.shape[0]} entries to match the rows, got {rhs.shape[0]}"
+            raise ValueError(msg)
+
+    def trace(self) -> CLA:
+        """Assemble the pieces, build the ``CLA``, and run the full trace.
+
+        Returns:
+            The solved :class:`cvxcla.cla.CLA`, whose ``frontier`` and
+            ``turning_points`` describe the entire efficient frontier.
+
+        Raises:
+            ValueError: If no box bounds were set (call :meth:`bounds` or
+                :meth:`long_only`), or no equality constraint was added (call
+                :meth:`budget` or :meth:`equality`).
+        """
+        if self._lower is None or self._upper is None:
+            msg = "set box bounds before tracing: call .long_only() or .bounds(lower, upper)"
+            raise ValueError(msg)
+        if not self._a_blocks:
+            msg = "a CLA problem needs an equality constraint: call .budget() or .equality(A, b)"
+            raise ValueError(msg)
+
+        g = np.vstack(self._g_blocks) if self._g_blocks else None
+        h = np.concatenate(self._h_blocks) if self._h_blocks else None
+        return CLA(
+            mean=self.mean,
+            covariance=self.covariance,
+            lower_bounds=self._lower,
+            upper_bounds=self._upper,
+            a=np.vstack(self._a_blocks),
+            b=np.concatenate(self._b_blocks),
+            g=g,
+            h=h,
+        )

--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -9,10 +9,13 @@ set of assets at their bounds changes.
 import logging
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from .builder import ProblemBuilder
 
 from .first import first_vertex_lp, init_algo
 from .operators import DenseCovariance, QuadraticForm
@@ -111,6 +114,26 @@ class CLA:
     turning_points: list[TurningPoint] = field(default_factory=list)
     tol: float = 1e-5  # pragma: no mutate
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+    @classmethod
+    def problem(cls, mean: NDArray[np.float64], covariance: NDArray[np.float64] | QuadraticForm) -> "ProblemBuilder":
+        """Start a fluent :class:`cvxcla.builder.ProblemBuilder` for this problem.
+
+        A readability convenience over the explicit constructor: chain
+        ``.long_only()``/``.budget()``/``.equality()``/``.inequality()`` and finish
+        with ``.trace()``. The builder maps one-to-one onto the constructor
+        arguments and adds no modelling power.
+
+        Args:
+            mean: Vector of expected returns of length ``n``.
+            covariance: Covariance matrix or ``QuadraticForm`` backend.
+
+        Returns:
+            A ``ProblemBuilder`` ready to accept constraints.
+        """
+        from .builder import ProblemBuilder
+
+        return ProblemBuilder(mean, covariance)
 
     @cached_property
     def covariance_operator(self) -> QuadraticForm:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,171 @@
+"""Tests for the fluent ``ProblemBuilder`` convenience layer.
+
+The builder is sugar over the explicit ``CLA(...)`` constructor, so the central
+guarantee is equivalence: a problem assembled through the builder must produce
+exactly the same frontier as the same problem passed to the constructor
+directly. The rest of the suite covers the ergonomic helpers and the
+actionable validation errors.
+"""
+
+import numpy as np
+import pytest
+
+from cvxcla import CLA, FactorCovariance, ProblemBuilder
+
+
+@pytest.fixture
+def problem():
+    """A small, well-conditioned long-only problem (mean, covariance)."""
+    rng = np.random.default_rng(0)
+    n = 6
+    mean = rng.uniform(0.0, 1.0, n)
+    factors = rng.standard_normal((n, n))
+    covariance = factors @ factors.T + n * np.eye(n)
+    return mean, covariance
+
+
+def _same_frontier(a: CLA, b: CLA) -> bool:
+    """Whether two traces have identical turning-point weights."""
+    if len(a) != len(b):
+        return False
+    return all(np.allclose(p.weights, q.weights) for p, q in zip(a.turning_points, b.turning_points, strict=True))
+
+
+class TestEquivalence:
+    """The builder must reproduce the explicit constructor exactly."""
+
+    def test_long_only_budget_matches_constructor(self, problem):
+        """long_only().budget() equals the canonical all-ones budget construction."""
+        mean, covariance = problem
+        n = len(mean)
+        built = CLA.problem(mean, covariance).long_only().budget().trace()
+        explicit = CLA(
+            mean=mean,
+            covariance=covariance,
+            lower_bounds=np.zeros(n),
+            upper_bounds=np.ones(n),
+            a=np.ones((1, n)),
+            b=np.ones(1),
+        )
+        assert _same_frontier(built, explicit)
+
+    def test_inequality_matches_constructor(self, problem):
+        """An inequality row through the builder matches the explicit g/h arguments."""
+        mean, covariance = problem
+        n = len(mean)
+        # Per-asset cap of 0.3 forces the max-return vertex to spread across
+        # several assets, so the first vertex is non-degenerate and the row
+        # binds along the trace.
+        g = np.zeros((1, n))
+        g[0, :3] = 1.0  # cap the first three assets' combined weight
+        h = np.array([0.5])
+        built = CLA.problem(mean, covariance).long_only(0.3).budget().inequality(g[0], 0.5).trace()
+        explicit = CLA(
+            mean=mean,
+            covariance=covariance,
+            lower_bounds=np.zeros(n),
+            upper_bounds=np.full(n, 0.3),
+            a=np.ones((1, n)),
+            b=np.ones(1),
+            g=g,
+            h=h,
+        )
+        assert _same_frontier(built, explicit)
+
+    def test_factor_backend_passes_through(self, problem):
+        """A QuadraticForm backend reaches CLA unchanged (structured solve preserved)."""
+        mean, _ = problem
+        n = len(mean)
+        rng = np.random.default_rng(1)
+        backend = FactorCovariance(d=np.full(n, 1.0), u=rng.standard_normal((n, 2)), delta=np.array([1.0, 2.0]))
+        built = CLA.problem(mean, backend).long_only().budget().trace()
+        explicit = CLA(
+            mean=mean,
+            covariance=backend,
+            lower_bounds=np.zeros(n),
+            upper_bounds=np.ones(n),
+            a=np.ones((1, n)),
+            b=np.ones(1),
+        )
+        assert built.covariance is backend
+        assert _same_frontier(built, explicit)
+
+
+class TestErgonomics:
+    """The named helpers behave as documented."""
+
+    def test_problem_returns_builder(self, problem):
+        """CLA.problem yields a ProblemBuilder fixed to the given dimension."""
+        mean, covariance = problem
+        builder = CLA.problem(mean, covariance)
+        assert isinstance(builder, ProblemBuilder)
+        assert builder._n == len(mean)
+
+    def test_bounds_scalar_and_array(self, problem):
+        """The bounds setter accepts both scalars (broadcast) and length-n arrays."""
+        mean, covariance = problem
+        n = len(mean)
+        upper = np.full(n, 0.5)
+        scalar = CLA.problem(mean, covariance).bounds(0.0, 0.5).budget().trace()
+        array = CLA.problem(mean, covariance).bounds(np.zeros(n), upper).budget().trace()
+        assert _same_frontier(scalar, array)
+        assert np.all(scalar.upper_bounds == 0.5)
+
+    def test_long_only_custom_upper(self, problem):
+        """long_only(upper) sets the upper cap and keeps the zero floor."""
+        mean, covariance = problem
+        cla = CLA.problem(mean, covariance).long_only(0.4).budget().trace()
+        assert np.all(cla.lower_bounds == 0.0)
+        assert np.all(cla.upper_bounds == 0.4)
+
+    def test_budget_total(self, problem):
+        """budget(total) sets the right-hand side of the all-ones equality."""
+        mean, covariance = problem
+        cla = CLA.problem(mean, covariance).long_only(2.0).budget(2.0).trace()
+        assert cla.b == pytest.approx([2.0])
+        assert np.allclose(cla.a, 1.0)
+
+    def test_general_equality_matrix_and_accumulation(self, problem):
+        """The equality method accepts a matrix block and accumulates across calls."""
+        mean, covariance = problem
+        n = len(mean)
+        extra = np.zeros(n)
+        extra[0] = 1.0  # pin the first asset's weight
+        cla = CLA.problem(mean, covariance).bounds(-1.0, 1.0).budget().equality(extra, 0.1).trace()
+        assert cla.a.shape == (2, n)  # budget row plus the pin
+        assert cla.b == pytest.approx([1.0, 0.1])
+
+
+class TestValidation:
+    """Mistakes are rejected with actionable messages."""
+
+    def test_trace_without_bounds_raises(self, problem):
+        """Tracing before setting bounds names the fix."""
+        mean, covariance = problem
+        with pytest.raises(ValueError, match="set box bounds"):
+            CLA.problem(mean, covariance).budget().trace()
+
+    def test_trace_without_equality_raises(self, problem):
+        """Tracing without any equality constraint names the fix."""
+        mean, covariance = problem
+        with pytest.raises(ValueError, match="needs an equality constraint"):
+            CLA.problem(mean, covariance).long_only().trace()
+
+    def test_bounds_wrong_length_raises(self, problem):
+        """A bounds vector of the wrong length is rejected."""
+        mean, covariance = problem
+        with pytest.raises(ValueError, match="length-6 vector"):
+            CLA.problem(mean, covariance).bounds(0.0, np.ones(3))
+
+    def test_equality_wrong_width_raises(self, problem):
+        """An equality row with the wrong number of columns is rejected."""
+        mean, covariance = problem
+        with pytest.raises(ValueError, match="must have 6 columns"):
+            CLA.problem(mean, covariance).equality(np.ones(3), 1.0)
+
+    def test_inequality_rhs_mismatch_raises(self, problem):
+        """An inequality block whose rhs length disagrees with its rows is rejected."""
+        mean, covariance = problem
+        n = len(mean)
+        with pytest.raises(ValueError, match="to match the rows"):
+            CLA.problem(mean, covariance).inequality(np.ones((2, n)), np.ones(3))


### PR DESCRIPTION
## Summary

Adds a thin, chainable builder over the explicit `CLA(...)` constructor, reached via `CLA.problem(...)`:

```python
cla = CLA.problem(mean, Sigma).long_only().budget().trace()
```

Each step maps **one-to-one** onto a constructor argument — `.bounds(lower, upper)`, `.long_only(upper=1)`, `.budget(total=1)`, `.equality(A, b)`, `.inequality(G, h)` — and the terminal `.trace()` builds the `CLA` and runs the full parametric trace, returning the solved object (whole frontier, not a single optimum).

### Design (deliberately minimal)

- **Pure sugar.** No modelling power beyond the constructor, and **no expression algebra** (no cvxpy-style `G @ w <= h` parsing). It accepts only the polyhedral pieces the CLA already supports, so anything the constructor can't trace, the builder can't express either — no class of confusing "unsupported expression" errors.
- **Structured backends preserved.** A `QuadraticForm` covariance (e.g. `FactorCovariance`) is passed through unchanged, so the Woodbury/Gram solves keep their advantage.
- **Actionable validation.** Shape mismatches and missing bounds/equality are rejected with messages that name the fix.

### Paper

Section 9 ("Using the package") gains a listing (`lst:builder`) showing the fluent form reproduces the **identical** frontier as the explicit constructor (verified: 7 turning points, max Sharpe 2.4037).

## Tests

- Constructor-equivalence: dense, factor backend, and inequality-constrained problems.
- Ergonomic helpers (scalar/array bounds, custom caps, budget total, matrix equality + accumulation).
- Validation errors (missing bounds, missing equality, wrong width, rhs mismatch).
- `builder.py` and `cla.py` remain at **100% coverage**; full suite 236 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)