### PR TITLE
feat: constrained + non-negative LASSO, fluent builder, README; paper flow cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ for portfolio optimization.
 The CLA efficiently computes the entire efficient frontier for portfolio optimization
 problems with linear constraints and bounds on the weights.
 
+The same parametric active-set engine also traces the **LASSO** regularisation path
+(the `Lasso` class) — including general inequality constraints `Gβ ≤ h` and the
+non-negative LASSO `β ≥ 0` — so the Critical Line Algorithm and the LARS/LASSO
+homotopy come out as two instances of one path-following engine.
+
 The Critical Line Algorithm was introduced by Harry Markowitz
 in [The Optimization of Quadratic Functions Subject to Linear Constraints](https://www.rand.org/pubs/research_memoranda/RM1438.html)
 and further described in his book [Portfolio Selection](https://www.wiley.com/en-us/Portfolio+Selection%3A+Efficient+Diversification+of+Investments%2C+2nd+Edition-p-9781557861085).
@@ -96,6 +101,9 @@ approximation needed.
   Woodbury identity
 - Visualization of the efficient frontier using Plotly
 - Computation of the maximum Sharpe ratio portfolio
+- **LASSO regularisation path** through the same engine (`Lasso`), with the same
+  fluent builder, general inequality constraints `Gβ ≤ h`, and the non-negative
+  LASSO `β ≥ 0`
 - Fully tested and documented codebase
 
 ## 🚀 Installation
@@ -263,6 +271,49 @@ covariance = FactorCovariance(
 
 See the [factor backend documentation](https://www.cvxgrp.org/cvxcla/factor/)
 for the protocol, the math, and benchmarks against the dense path.
+
+### The LASSO through the same engine
+
+The same path-tracer drives the LASSO regularisation path. `Lasso` plays the Gram
+matrix `XᵀX` and the vector `Xᵀy` the way the CLA plays the covariance and the mean,
+and traces the whole path from `λ_max` (where `β = 0`) down to the least-squares fit:
+
+```python
+import numpy as np
+from cvxcla import Lasso
+
+rng = np.random.default_rng(0)
+X = rng.standard_normal((60, 12))
+y = X @ rng.standard_normal(12) + 0.1 * rng.standard_normal(60)
+
+# plain LASSO path; .solution(lam) evaluates beta at any penalty
+lasso = Lasso(x=X, y=y)
+beta = lasso.solution(0.5 * lasso.lam_max)
+
+# the same fluent builder as the CLA
+lasso = Lasso.problem(X, y).trace()
+```
+
+It carries the same constraints the CLA does. Add general inequality rows `Gβ ≤ h`
+(with `h > 0`, e.g. per-group exposure caps), or restrict to the **non-negative
+LASSO** `β ≥ 0` — where the ℓ₁ penalty collapses to the linear term `λ·1ᵀβ`, making
+it exactly the CLA's box-bounded parametric QP:
+
+```python
+# group-exposure caps G beta <= h (cap features 0–3 and 4–7)
+G = np.zeros((2, 12))
+G[0, :4] = 1.0
+G[1, 4:8] = 1.0
+h = np.array([1.0, 1.0])
+lasso = Lasso.problem(X, y).inequality(G, h).trace()
+
+# non-negative LASSO (beta >= 0)
+lasso = Lasso.problem(X, y).non_negative().trace()
+```
+
+Both return the exact path, validated breakpoint-by-breakpoint against a per-λ QP
+solver. (Equality constraints `Aβ = b` need a feasibility seed and are not yet
+supported; the canonical sum-to-zero case cannot be traced one coordinate at a time.)
 
 ## 🧪 Testing
 

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -106,7 +106,10 @@ models (diagonal plus low rank) trace the same exact frontier without ever
 materialising a dense $n\times n$ matrix, at a fraction of the cost when their
 structure is genuinely low-rank. Second, a \emph{unification}: the CLA is the
 one-parameter specialisation of multi-parametric quadratic programming and shares
-its mechanics with the LARS/LASSO homotopy of statistical learning. Third, an
+its mechanics with the LARS/LASSO homotopy of statistical learning, so the same
+path-tracing engine, carrying the same general linear constraints, returns the exact
+constrained efficient frontier and the exact constrained LASSO regularisation path
+alike. Third, an
 \emph{open, tested, and benchmarked implementation}, with event logic hardened
 against degeneracy and floating-point noise.
 
@@ -1785,6 +1788,40 @@ implementations agree to solver precision ($\approx 3\times 10^{-15}$), confirmi
 that the CLA engine and the LARS/LASSO homotopy trace the identical path.}
 \label{fig:lasso}
 \end{figure}
+
+\subsection{A constrained LASSO through the same engine}
+\label{sec:lassoconstrained}
+
+The unification is not confined to the textbook LASSO. The same general linear
+inequality constraints the CLA carries, $G\beta \le h$, drop into the LASSO path
+unchanged: an active row enters the reduced system as the bordered Schur complement
+of \S\ref{sec:blockelim}, and the generalised correlation that drives the
+enter/leave events simply carries the active-row multipliers,
+$X\trans(y - X\beta(\lambda)) - G_{\Sset}\trans\eta(\lambda)$. The path stays
+piecewise linear (a quadratic loss under a polyhedral penalty \emph{and} polyhedral
+constraints, the criterion of \citet{rosset2007}), and \texttt{cvxcla.Lasso} accepts
+$G,h$ exactly as the \texttt{CLA} does. We require $h > 0$ so the path can start from
+the feasible $\beta = 0$ with every row slack, the same first vertex as the
+unconstrained LASSO; an equality system $A\beta = b$, or a zero entry of $h$, would
+need the linear-programming feasibility seed of \S\ref{sec:first} and is left to
+future work. On a standardised $60\times 12$ regression with per-group exposure caps
+$G\beta \le h$ ($15$ breakpoints, a cap active at $9$ of the $14$ interior segments),
+every segment midpoint matches a per-$\lambda$ constrained QP solve (CVXPY/Clarabel)
+to $\approx 2\times 10^{-10}$ in coefficients and to machine precision in feasibility
+(\srcfile{experiments/validate_lasso_constraints.py}{validate\_lasso\_constraints.py}),
+so the one path-tracing engine returns the exact \emph{constrained} regularisation
+path as well as the exact constrained frontier. The fluent builder of
+\S\ref{sec:usage} carries over unchanged, so the constrained path reads the same way
+as the constrained frontier (Listing~\ref{lst:lassobuilder}).
+
+\begin{lstlisting}[style=pyin,caption={The constrained LASSO through the same fluent
+builder as the CLA: \texttt{.inequality(G, h)} then \texttt{.trace()}.},label={lst:lassobuilder}]
+from cvxcla import Lasso
+
+# per-group exposure caps G beta <= h on a standardised regression
+lasso = Lasso.problem(X, y).inequality(G, h).trace()
+print("breakpoints:", len(lasso.path))
+\end{lstlisting}
 
 \section{Conclusion}
 

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -73,9 +73,9 @@
 \newcommand{\srcref}{v1.8.0}
 \newcommand{\srcfile}[2]{\href{\repourl/blob/\srcref/#1}{\texttt{#2}}}
 
-\title{\textbf{Exact Constrained Solution Paths for Portfolio Optimization
-and the LASSO}\\[0.3em]
-\large A parametric active-set method, as implemented in \texttt{cvxcla}}
+\title{\textbf{The Critical Line Algorithm}\\[0.3em]
+\large A parametric active-set method for the constrained mean--variance efficient
+frontier, with a LARS/LASSO twin, as implemented in \texttt{cvxcla}}
 
 \author{Thomas Schmelzer\\[2pt]
 \normalsize Jebel Quant Research, Abu Dhabi}
@@ -222,6 +222,16 @@ equality system, where the free set is too small to span the constraints
 trace deterministic on the degenerate problems we test but is not proven to defuse
 every adversarial tie-heavy or very large instance; tracing through these declined
 cases is left to future work.
+
+One thread runs throughout. The critical-line iteration is a \emph{parametric
+active-set homotopy}, the same family as the LARS/LASSO path of statistical
+learning: a strictly convex quadratic whose linear term moves with a scalar
+parameter, traced from one breakpoint to the next while an active set is
+maintained. The portfolio frontier stays in the foreground, but the identical
+path-tracing engine, with the covariance replaced by a Gram matrix, traces the
+(constrained) LASSO regularisation path; \S\ref{sec:lars} makes the correspondence
+literal and runs both through one implementation. We flag it here so the machinery
+below reads as a general path-follower, not a portfolio-only tool.
 
 The accompanying \texttt{cvxcla}
 package\footnote{\href{\repourl}{\texttt{github.com/cvxgrp/cvxcla}}} provides the
@@ -768,7 +778,7 @@ $\lVert w\rVert_1 \le c$ is instead polyhedral, expressible as $G w \le h$ under
 split $w = w^+ - w^-$. Genuinely nonquadratic penalties (an entropy or log-barrier
 term) break the linear-in-$\lambda$ structure and lie outside the method.
 
-\section{The efficient frontier object}
+\section{The frontier object and its properties}
 \label{sec:frontier}
 
 The list of turning points is wrapped in a \texttt{Frontier} object
@@ -796,7 +806,7 @@ point of largest discrete Sharpe ratio brackets the continuous maximum. The
 frontier object therefore returns the maximum-Sharpe portfolio exactly, not to a
 search tolerance.
 
-\section{Complexity and properties}
+Four properties of the traced frontier are worth recording explicitly.
 
 \begin{itemize}
 \item \textbf{Exactness.} The frontier is returned exactly as a finite set of turning
@@ -830,136 +840,6 @@ complete with optimal turning points (\S\ref{sec:empirical}). The tie-break is r
 on the degenerate problems we test but is not proven to defuse every degeneracy;
 \S\ref{sec:empirical} states this boundary precisely.
 \end{itemize}
-
-\section{Relation to the Bailey--L\'opez de Prado implementation}
-\label{sec:bailey}
-
-The most widely used open implementation of the CLA is that of
-\citet{bailey2013} (the implementation behind PyPortfolioOpt's \texttt{CLA}
-\citep{pyportfolioopt}, against which we benchmark in \S\ref{sec:experiment}).
-That paper is the reference open-source CLA; when published it filled a real gap,
-as the only prior documented implementation was the Markowitz--Todd VBA-Excel code
-of \citet{markowitz2000}. Our
-implementation in fact shares several of its design choices: the same greedy
-first turning point (\S\ref{sec:first}), the explicit minimum-variance endpoint
-at $\lambda = 0$, and locating the maximum-Sharpe portfolio between bracketing
-turning points (\S\ref{sec:frontier}, in closed form here). It traces the same
-turning points as the method described here, since the underlying mathematics is
-Markowitz's, but differs in four ways that matter in practice.
-
-\begin{enumerate}
-\item \textbf{Covariance representation.} Bailey--L\'opez de Prado operate on an
-\emph{explicit dense covariance matrix}: each turning point forms and inverts the
-free-block covariance $\Sig_{\F\F}$ directly (their \texttt{getMatrices} /
-\texttt{reduceMatrix} helpers slice the stored matrix). \texttt{cvxcla} never
-requires the matrix: it reaches the covariance only through the operator protocol
-of \S\ref{sec:operators}, so structured backends (the diagonal-plus-low-rank
-Woodbury solve) plug in unchanged. This is the central difference and the source
-of the asymptotic speed-up in \S\ref{sec:rankscaling}.
-
-\item \textbf{Linear algebra.} Where the reference algorithm forms an explicit
-inverse of the free block from scratch at each step (and, in the branch that
-decides which blocked asset re-enters, recomputes that full inverse once for every
-candidate), \texttt{cvxcla} casts each step as the reduced KKT saddle-point solve
-of \S\ref{sec:blockelim}: a single block-eliminated solve against $\Sig_{\F\F}$
-feeding an $m \times m$ Schur complement, with the event search over all
-candidates vectorised rather than looped. More fundamentally, Bailey--L\'opez de
-Prado never assemble a KKT system at all: they substitute an explicit
-$\Sig_{\F\F}\inv$ into closed-form Lagrange expressions for $\lambda$, $\gamma$,
-and $w_\F$ specialised to the single budget row. The saddle-point formulation is
-what lets \texttt{cvxcla} reach the covariance as a black-box solve (the backend
-abstraction) and take an arbitrary $A$ (next point) where their closed-form
-algebra admits only one.
-
-\item \textbf{Constraint generality.} The reference implementation targets box
-bounds plus a single budget (fully-invested) constraint. \texttt{cvxcla} admits
-an arbitrary set of $m$ linear equality constraints $A w = b$ and $p$ linear
-inequality constraints $G w \le h$; the budget is just the case
-$A = \mathbf{1}\trans$, $b = 1$, $p = 0$, and the Schur complement scales to
-$m + |\Sset| > 1$ active rows at negligible cost. The turning-point loop is general
-in $A$ throughout, and an active inequality row is carried as an extra row of that
-Schur complement (\S\ref{sec:lars}); the only constraint-specific step is the
-maximum-return vertex that seeds it, found by the greedy fill for an all-ones budget
-and by a linear program (HiGHS, via \texttt{scipy}) for a general $A$ or any $G$
-(\S\ref{sec:first}). This covers leverage, dollar-neutral long/short books, multi-row
-neutralities (sector, factor), and group- or sector-exposure caps. One
-caveat mirrors the degeneracy guarantee of \S\ref{sec:empirical}: the general-$A$
-path assumes a well-conditioned first vertex, where the free set has the $m$ assets
-the equalities require. At a \emph{degenerate} vertex (a basic asset pinned exactly
-on a box bound, so the free set is too small to span the constraints) the reduced
-$A_\F$ loses row rank and the Schur complement is singular. That vertex is
-\emph{declined} at the first turning point with an actionable diagnosis rather than
-mis-solved; tracing through it (rather than declining) is left to future work
-alongside the tie-heavy hardening of \S\ref{sec:empirical}.
-
-\item \textbf{Degeneracy handling.} On tie-heavy or degenerate inputs several
-events can share the same critical $\lambda$. \texttt{cvxcla} applies an explicit
-Bland-style, lowest-index tie-break (\S\ref{sec:bland}) together with a
-floating-point slope floor (\S\ref{sec:events}) to keep the trace deterministic
-and bounded; the reference implementation has no comparable anti-cycling rule. It
-also projects the sub-tolerance round-off that near-degenerate vertices produce
-back onto the feasible set, so near-rank-deficient covariances trace to
-completion with optimal turning points; only a genuinely rank-deficient free
-block is declined (\S\ref{sec:empirical}).
-\end{enumerate}
-
-These differences compound into a large runtime gap (\S\ref{sec:experiment}). It
-would be tempting to dismiss the gap as ``just an implementation detail,'' but the
-reference implementation is not slow for lack of \texttt{numpy}: it uses
-\texttt{numpy} for its per-step algebra. It is slow because of the structure
-above: a full free-block inverse rebuilt every step, and rebuilt once per
-candidate in the asset-entry search. \S\ref{sec:baseline} pins this down with a
-controlled baseline.
-
-\paragraph{Relation to large-scale active-set methods.}
-Bailey--L\'opez de Prado is the natural baseline because it is the most widely
-used open CLA, but it is not the only line of work on tracing the frontier
-efficiently. \citet{perold1984}, \citet{stein2008} and \citet{hirschberger2010}
-develop parametric quadratic-programming and active-set methods aimed squarely at
-\emph{large} universes, and they too drive the per-step cost well below a dense
-$O(n_\F^3)$ refactorisation. The decisive difference is \emph{where} the speed-up
-comes from. Those methods accelerate the linear algebra of a covariance that is
-still treated as an explicit (if large and possibly sparse) matrix (through
-incremental factorisation updates, exploitation of sparsity, or specialised
-pivoting) so the gain is tied to a particular matrix representation baked into
-the solver. \texttt{cvxcla} instead leaves the turning-point loop entirely
-representation-agnostic: the covariance enters only through the three-operation
-operator protocol of \S\ref{sec:operators}, so the same loop runs unchanged on a
-dense matrix or on a diagonal-plus-low-rank factor model, and the asymptotic
-advantage of \S\ref{sec:rankscaling} is a property of the \emph{backend}, not of
-the algorithm. The two ideas are complementary rather than competing: an
-incremental-update solver for the free block could itself be wrapped as a
-\texttt{CovarianceOperator} and dropped in. A direct empirical comparison is left
-to future work, for a concrete reason: no maintained, installable fast large-scale
-CLA exists to benchmark against. The closest is the Fortran implementation of
-\citet{niedermayer2010} (with MATLAB and Python bindings), which reports speedups
-of several orders of magnitude over earlier CLA codes but is effectively
-unmaintained and not buildable on current toolchains without nontrivial effort;
-\citet{hirschberger2010}'s ``CIOS'' is self-contained Java research code; and a
-general parametric active-set QP solver such as qpOASES would have to be driven
-along $\lambda$ with warm starts rather than tracing the frontier natively.
-Reviving the Niedermayer code, or a $\lambda$-swept qpOASES, is the natural
-baseline for such a comparison. The reading here is that \texttt{cvxcla}'s
-contribution is the interface that makes such backends interchangeable, not a
-claim to the fastest dense large-scale solve.
-
-\paragraph{Relation to portfolio-optimization software.}
-Set against the broader ecosystem of portfolio-optimization packages, the
-distinction is less speed than \emph{what is computed}. General toolkits, in Python
-Riskfolio-Lib \citep{riskfolio} and the scikit-learn-based \texttt{skfolio}
-\citep{skfolio}, and in R \texttt{fPortfolio} \citep{fportfolio} and the
-disciplined-convex layer \texttt{CVXR} \citep{cvxr}, construct a portfolio by
-solving a (mean--variance or richer) optimisation at a \emph{single} risk target,
-typically by handing a quadratic or conic program to a general solver; recovering
-the frontier then means re-solving on a grid of targets, an approximation that the
-grid resolution controls. \texttt{cvxcla}, like the CLA itself and like
-PyPortfolioOpt's \texttt{CLA} \citep{pyportfolioopt}, instead returns the
-\emph{entire} frontier exactly as a finite set of turning points, with no grid.
-Among the exact-CLA tools, PyPortfolioOpt is the natural head-to-head
-(\S\ref{sec:experiment}) but, as noted there, is not a performance-tuned solver. What is genuinely particular to \texttt{cvxcla} is
-orthogonal to all of these: the operator interface and the structured factor and
-Gram backends (\S\ref{sec:operators}), which run the same exact-frontier trace
-directly on a covariance representation the general toolkits do not exploit.
 
 \section{Using the package}
 \label{sec:usage}
@@ -1117,6 +997,136 @@ script, \srcfile{experiments/reproduce_paper.py}{reproduce\_paper.py},
 which runs each experiment in turn off the committed inputs (no network access)
 and reports which artefact it produces; the individual scripts it calls are cited
 at the relevant figures and tables below.
+
+\section{Relation to the Bailey--L\'opez de Prado implementation}
+\label{sec:bailey}
+
+The most widely used open implementation of the CLA is that of
+\citet{bailey2013} (the implementation behind PyPortfolioOpt's \texttt{CLA}
+\citep{pyportfolioopt}, against which we benchmark in \S\ref{sec:experiment}).
+That paper is the reference open-source CLA; when published it filled a real gap,
+as the only prior documented implementation was the Markowitz--Todd VBA-Excel code
+of \citet{markowitz2000}. Our
+implementation in fact shares several of its design choices: the same greedy
+first turning point (\S\ref{sec:first}), the explicit minimum-variance endpoint
+at $\lambda = 0$, and locating the maximum-Sharpe portfolio between bracketing
+turning points (\S\ref{sec:frontier}, in closed form here). It traces the same
+turning points as the method described here, since the underlying mathematics is
+Markowitz's, but differs in four ways that matter in practice.
+
+\begin{enumerate}
+\item \textbf{Covariance representation.} Bailey--L\'opez de Prado operate on an
+\emph{explicit dense covariance matrix}: each turning point forms and inverts the
+free-block covariance $\Sig_{\F\F}$ directly (their \texttt{getMatrices} /
+\texttt{reduceMatrix} helpers slice the stored matrix). \texttt{cvxcla} never
+requires the matrix: it reaches the covariance only through the operator protocol
+of \S\ref{sec:operators}, so structured backends (the diagonal-plus-low-rank
+Woodbury solve) plug in unchanged. This is the central difference and the source
+of the asymptotic speed-up in \S\ref{sec:rankscaling}.
+
+\item \textbf{Linear algebra.} Where the reference algorithm forms an explicit
+inverse of the free block from scratch at each step (and, in the branch that
+decides which blocked asset re-enters, recomputes that full inverse once for every
+candidate), \texttt{cvxcla} casts each step as the reduced KKT saddle-point solve
+of \S\ref{sec:blockelim}: a single block-eliminated solve against $\Sig_{\F\F}$
+feeding an $m \times m$ Schur complement, with the event search over all
+candidates vectorised rather than looped. More fundamentally, Bailey--L\'opez de
+Prado never assemble a KKT system at all: they substitute an explicit
+$\Sig_{\F\F}\inv$ into closed-form Lagrange expressions for $\lambda$, $\gamma$,
+and $w_\F$ specialised to the single budget row. The saddle-point formulation is
+what lets \texttt{cvxcla} reach the covariance as a black-box solve (the backend
+abstraction) and take an arbitrary $A$ (next point) where their closed-form
+algebra admits only one.
+
+\item \textbf{Constraint generality.} The reference implementation targets box
+bounds plus a single budget (fully-invested) constraint. \texttt{cvxcla} admits
+an arbitrary set of $m$ linear equality constraints $A w = b$ and $p$ linear
+inequality constraints $G w \le h$; the budget is just the case
+$A = \mathbf{1}\trans$, $b = 1$, $p = 0$, and the Schur complement scales to
+$m + |\Sset| > 1$ active rows at negligible cost. The turning-point loop is general
+in $A$ throughout, and an active inequality row is carried as an extra row of that
+Schur complement (\S\ref{sec:lars}); the only constraint-specific step is the
+maximum-return vertex that seeds it, found by the greedy fill for an all-ones budget
+and by a linear program (HiGHS, via \texttt{scipy}) for a general $A$ or any $G$
+(\S\ref{sec:first}). This covers leverage, dollar-neutral long/short books, multi-row
+neutralities (sector, factor), and group- or sector-exposure caps. One
+caveat mirrors the degeneracy guarantee of \S\ref{sec:empirical}: the general-$A$
+path assumes a well-conditioned first vertex, where the free set has the $m$ assets
+the equalities require. At a \emph{degenerate} vertex (a basic asset pinned exactly
+on a box bound, so the free set is too small to span the constraints) the reduced
+$A_\F$ loses row rank and the Schur complement is singular. That vertex is
+\emph{declined} at the first turning point with an actionable diagnosis rather than
+mis-solved; tracing through it (rather than declining) is left to future work
+alongside the tie-heavy hardening of \S\ref{sec:empirical}.
+
+\item \textbf{Degeneracy handling.} On tie-heavy or degenerate inputs several
+events can share the same critical $\lambda$. \texttt{cvxcla} applies an explicit
+Bland-style, lowest-index tie-break (\S\ref{sec:bland}) together with a
+floating-point slope floor (\S\ref{sec:events}) to keep the trace deterministic
+and bounded; the reference implementation has no comparable anti-cycling rule. It
+also projects the sub-tolerance round-off that near-degenerate vertices produce
+back onto the feasible set, so near-rank-deficient covariances trace to
+completion with optimal turning points; only a genuinely rank-deficient free
+block is declined (\S\ref{sec:empirical}).
+\end{enumerate}
+
+These differences compound into a large runtime gap (\S\ref{sec:experiment}). It
+would be tempting to dismiss the gap as ``just an implementation detail,'' but the
+reference implementation is not slow for lack of \texttt{numpy}: it uses
+\texttt{numpy} for its per-step algebra. It is slow because of the structure
+above: a full free-block inverse rebuilt every step, and rebuilt once per
+candidate in the asset-entry search. \S\ref{sec:baseline} pins this down with a
+controlled baseline.
+
+\paragraph{Relation to large-scale active-set methods.}
+Bailey--L\'opez de Prado is the natural baseline because it is the most widely
+used open CLA, but it is not the only line of work on tracing the frontier
+efficiently. \citet{perold1984}, \citet{stein2008} and \citet{hirschberger2010}
+develop parametric quadratic-programming and active-set methods aimed squarely at
+\emph{large} universes, and they too drive the per-step cost well below a dense
+$O(n_\F^3)$ refactorisation. The decisive difference is \emph{where} the speed-up
+comes from. Those methods accelerate the linear algebra of a covariance that is
+still treated as an explicit (if large and possibly sparse) matrix (through
+incremental factorisation updates, exploitation of sparsity, or specialised
+pivoting) so the gain is tied to a particular matrix representation baked into
+the solver. \texttt{cvxcla} instead leaves the turning-point loop entirely
+representation-agnostic: the covariance enters only through the three-operation
+operator protocol of \S\ref{sec:operators}, so the same loop runs unchanged on a
+dense matrix or on a diagonal-plus-low-rank factor model, and the asymptotic
+advantage of \S\ref{sec:rankscaling} is a property of the \emph{backend}, not of
+the algorithm. The two ideas are complementary rather than competing: an
+incremental-update solver for the free block could itself be wrapped as a
+\texttt{CovarianceOperator} and dropped in. A direct empirical comparison is left
+to future work, for a concrete reason: no maintained, installable fast large-scale
+CLA exists to benchmark against. The closest is the Fortran implementation of
+\citet{niedermayer2010} (with MATLAB and Python bindings), which reports speedups
+of several orders of magnitude over earlier CLA codes but is effectively
+unmaintained and not buildable on current toolchains without nontrivial effort;
+\citet{hirschberger2010}'s ``CIOS'' is self-contained Java research code; and a
+general parametric active-set QP solver such as qpOASES would have to be driven
+along $\lambda$ with warm starts rather than tracing the frontier natively.
+Reviving the Niedermayer code, or a $\lambda$-swept qpOASES, is the natural
+baseline for such a comparison. The reading here is that \texttt{cvxcla}'s
+contribution is the interface that makes such backends interchangeable, not a
+claim to the fastest dense large-scale solve.
+
+\paragraph{Relation to portfolio-optimization software.}
+Set against the broader ecosystem of portfolio-optimization packages, the
+distinction is less speed than \emph{what is computed}. General toolkits, in Python
+Riskfolio-Lib \citep{riskfolio} and the scikit-learn-based \texttt{skfolio}
+\citep{skfolio}, and in R \texttt{fPortfolio} \citep{fportfolio} and the
+disciplined-convex layer \texttt{CVXR} \citep{cvxr}, construct a portfolio by
+solving a (mean--variance or richer) optimisation at a \emph{single} risk target,
+typically by handing a quadratic or conic program to a general solver; recovering
+the frontier then means re-solving on a grid of targets, an approximation that the
+grid resolution controls. \texttt{cvxcla}, like the CLA itself and like
+PyPortfolioOpt's \texttt{CLA} \citep{pyportfolioopt}, instead returns the
+\emph{entire} frontier exactly as a finite set of turning points, with no grid.
+Among the exact-CLA tools, PyPortfolioOpt is the natural head-to-head
+(\S\ref{sec:experiment}) but, as noted there, is not a performance-tuned solver. What is genuinely particular to \texttt{cvxcla} is
+orthogonal to all of these: the operator interface and the structured factor and
+Gram backends (\S\ref{sec:operators}), which run the same exact-frontier trace
+directly on a covariance representation the general toolkits do not exploit.
 
 \section{Numerical experiment}
 \label{sec:experiment}

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -73,9 +73,9 @@
 \newcommand{\srcref}{v1.8.0}
 \newcommand{\srcfile}[2]{\href{\repourl/blob/\srcref/#1}{\texttt{#2}}}
 
-\title{\textbf{The Critical Line Algorithm}\\[0.3em]
-\large A parametric active-set method for the entire mean--variance efficient frontier,
-as implemented in \texttt{cvxcla}}
+\title{\textbf{Exact Constrained Solution Paths for Portfolio Optimization
+and the LASSO}\\[0.3em]
+\large A parametric active-set method, as implemented in \texttt{cvxcla}}
 
 \author{Thomas Schmelzer\\[2pt]
 \normalsize Jebel Quant Research, Abu Dhabi}

--- a/docs/paper/cla.tex
+++ b/docs/paper/cla.tex
@@ -1810,9 +1810,21 @@ every segment midpoint matches a per-$\lambda$ constrained QP solve (CVXPY/Clara
 to $\approx 2\times 10^{-10}$ in coefficients and to machine precision in feasibility
 (\srcfile{experiments/validate_lasso_constraints.py}{validate\_lasso\_constraints.py}),
 so the one path-tracing engine returns the exact \emph{constrained} regularisation
-path as well as the exact constrained frontier. The fluent builder of
-\S\ref{sec:usage} carries over unchanged, so the constrained path reads the same way
-as the constrained frontier (Listing~\ref{lst:lassobuilder}).
+path as well as the exact constrained frontier.
+
+The sign restriction $\beta \ge 0$ (the non-negative LASSO) is where the unification
+is most literal. With $\beta \ge 0$ the penalty $\lVert\beta\rVert_1 =
+\mathbf{1}\trans\beta$ becomes \emph{linear}, so the problem is exactly the CLA's
+box-bounded parametric quadratic program: Hessian $H = X\trans X$, lower bound $0$,
+and the $\lambda$-linear term $X\trans y - \lambda\mathbf{1}$. The homotopy is then
+the standard path restricted to positive signs (only the $+\lambda$ entry event,
+started from $\beta = 0$ at $\lambda_{\max} = \max_j (X\trans y)_j$). \texttt{cvxcla}
+traces it with \texttt{nonneg=True}, and every segment midpoint matches the
+per-$\lambda$ non-negative QP to $\approx 3\times10^{-11}$
+(\srcfile{experiments/validate_lasso_constraints.py}{validate\_lasso\_constraints.py}).
+The fluent builder of \S\ref{sec:usage} carries over unchanged for both, so a
+constrained or non-negative path reads the same way as the constrained frontier
+(Listing~\ref{lst:lassobuilder}).
 
 \begin{lstlisting}[style=pyin,caption={The constrained LASSO through the same fluent
 builder as the CLA: \texttt{.inequality(G, h)} then \texttt{.trace()}.},label={lst:lassobuilder}]
@@ -1821,6 +1833,9 @@ from cvxcla import Lasso
 # per-group exposure caps G beta <= h on a standardised regression
 lasso = Lasso.problem(X, y).inequality(G, h).trace()
 print("breakpoints:", len(lasso.path))
+
+# the non-negative LASSO (beta >= 0) is the same builder with one more step
+nonneg = Lasso.problem(X, y).non_negative().trace()
 \end{lstlisting}
 
 \section{Conclusion}

--- a/experiments/reproduce_paper.py
+++ b/experiments/reproduce_paper.py
@@ -17,6 +17,7 @@ degeneracy_boundary                 Figure 5  (degeneracy.pdf)
 tie_degeneracy                      Section 10.6 tie-heavy stress envelope
 clarabel_baseline                   Figure 6  (clarabel_baseline.pdf) + Section 10 baseline
 lasso_path                          Figure 7  (lasso_path.pdf) + Section 11 LASSO check
+validate_lasso_constraints          Section 11 constrained-LASSO exactness
 ==================================  ==========================================
 
 The S&P 500 input is the frozen snapshot committed at
@@ -59,6 +60,7 @@ STEPS: list[tuple[str, str, bool]] = [
     ("tie_degeneracy", "Section 10.6 tie-heavy stress envelope", False),
     ("clarabel_baseline", "Figure 6 (clarabel_baseline.pdf)", True),
     ("lasso_path", "Figure 7 (lasso_path.pdf) + Section 11 LASSO check", False),
+    ("validate_lasso_constraints", "Section 11 constrained-LASSO exactness", False),
 ]
 
 

--- a/experiments/validate_lasso_constraints.py
+++ b/experiments/validate_lasso_constraints.py
@@ -1,26 +1,31 @@
 """Validate the constrained LASSO path against a per-lambda general QP solver.
 
 ``cvxcla.Lasso`` traces the LASSO regularisation path through the same parametric
-active-set engine as the Critical Line Algorithm, and -- like the CLA -- it now
-admits general linear inequality constraints ``G beta <= h`` (with ``h > 0``, so the
-path starts from the feasible ``beta = 0``). This script checks that claim the same
-way ``validate_constraints.py`` checks the constrained frontier: it traces a
-constrained path and re-solves every segment midpoint as a general QP.
+active-set engine as the Critical Line Algorithm, and -- like the CLA -- it admits
+constraints: general linear inequalities ``G beta <= h`` (with ``h > 0``, so the path
+starts from the feasible ``beta = 0``) and the sign restriction ``beta >= 0`` (the
+non-negative LASSO, where the l1 penalty collapses to the linear term ``lam 1' beta``
+and only positive coefficients enter). This script checks both the same way
+``validate_constraints.py`` checks the constrained frontier: it traces a path and
+re-solves every segment midpoint as a general QP.
 
-For a deterministic standardised regression with a group-exposure cap ``G beta <= h``
-we
+For each scenario we
 
-  (a) trace the constrained path with ``cvxcla.Lasso``, and
+  (a) trace the path with ``cvxcla.Lasso``, and
   (b) at the midpoint ``lambda`` of every finite segment read the path coefficients
       and re-solve
 
-          min  1/2 ||y - X beta||^2 + lambda ||beta||_1   s.t.  G beta <= h
+          min  1/2 ||y - X beta||^2 + lambda ||beta||_1   s.t.  (constraints)
 
       from scratch with CVXPY / Clarabel (tight tolerances),
 
 and report the maximum coefficient discrepancy and the worst constraint violation.
-Agreement to solver tolerance, with the cap active along the path, confirms the
-constrained homotopy traces the exact constrained LASSO, not an approximation.
+
+Two scenarios:
+
+  1. inequality caps -- per-group exposure caps ``G beta <= h`` that bind along the
+     path;
+  2. non-negative -- the sign restriction ``beta >= 0``.
 
 Usage:
     uv run --with cvxpy python experiments/validate_lasso_constraints.py
@@ -41,68 +46,80 @@ N_GROUPS = 3
 SEED = 5
 
 
-def make_regression(rng: np.random.Generator) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Return (X, y, G, h): a standardised regression with binding group caps.
-
-    ``G`` sums the coefficients within each of ``N_GROUPS`` contiguous groups, and
-    ``h`` caps each group sum below its unconstrained least-squares level so the cap
-    genuinely binds along the path. ``h > 0`` keeps ``beta = 0`` feasible.
-    """
+def make_regression(rng: np.random.Generator) -> tuple[np.ndarray, np.ndarray]:
+    """A standardised design and centred response."""
     x = rng.standard_normal((N_OBS, N_FEATURES))
-    x = (x - x.mean(0)) / x.std(0)  # standardise columns
+    x = (x - x.mean(0)) / x.std(0)
     beta_true = rng.standard_normal(N_FEATURES)
     y = x @ beta_true + 0.1 * rng.standard_normal(N_OBS)
-    y = y - y.mean()
-
-    group = np.arange(N_FEATURES) % N_GROUPS
-    g = np.array([(group == j).astype(float) for j in range(N_GROUPS)])
-    beta_ols = np.linalg.lstsq(x, y, rcond=None)[0]
-    # cap each group sum at a positive fraction of its (absolute) OLS level
-    h = np.maximum(np.abs(g @ beta_ols) * 0.4, 0.1)
-    return x, y, g, h
+    return x, y - y.mean()
 
 
-def qp_solution(x: np.ndarray, y: np.ndarray, lam: float, g: np.ndarray, h: np.ndarray) -> np.ndarray:
+def qp_solution(
+    x: np.ndarray, y: np.ndarray, lam: float, g: np.ndarray | None, h: np.ndarray | None, nonneg: bool
+) -> np.ndarray:
     """Solve the constrained LASSO at penalty ``lam`` with CVXPY / Clarabel."""
-    n = x.shape[1]
-    beta = cp.Variable(n)
+    beta = cp.Variable(x.shape[1])
     objective = cp.Minimize(0.5 * cp.sum_squares(y - x @ beta) + lam * cp.norm1(beta))
-    cp.Problem(objective, [g @ beta <= h]).solve(
-        solver=cp.CLARABEL, tol_gap_abs=1e-12, tol_gap_rel=1e-12, tol_feas=1e-12
-    )
+    constraints = []
+    if g is not None:
+        constraints.append(g @ beta <= h)
+    if nonneg:
+        constraints.append(beta >= 0)
+    cp.Problem(objective, constraints).solve(solver=cp.CLARABEL, tol_gap_abs=1e-12, tol_gap_rel=1e-12, tol_feas=1e-12)
     return np.asarray(beta.value, dtype=float)
 
 
-def main() -> None:
-    """Trace the constrained LASSO and check every segment midpoint against a QP."""
-    rng = np.random.default_rng(SEED)
-    x, y, g, h = make_regression(rng)
-    lasso = Lasso(x=x, y=y, g=g, h=h)
-
+def validate(
+    label: str,
+    lasso: Lasso,
+    g: np.ndarray | None = None,
+    h: np.ndarray | None = None,
+    nonneg: bool = False,
+) -> float:
+    """Check every segment midpoint of a traced path against a per-lambda QP."""
+    x, y = lasso.x, lasso.y
     points = sorted(lasso.path, key=lambda bp: bp.lam)
-    errors = []
-    violations = []
-    active_mid = 0
+    errors: list[float] = []
+    viol: list[float] = []
     for lo, hi in pairwise(points):
         if hi.lam <= lasso.tol:
             continue
         lam = 0.5 * (lo.lam + hi.lam)
         beta_path = lasso.solution(lam)
-        beta_qp = qp_solution(x, y, lam, g, h)
-        errors.append(float(np.max(np.abs(beta_path - beta_qp))))
-        violations.append(float(np.max(g @ beta_path - h)))
-        if np.any(g @ beta_path - h > -1e-7):
-            active_mid += 1
+        errors.append(float(np.max(np.abs(beta_path - qp_solution(x, y, lam, g, h, nonneg)))))
+        if g is not None:
+            viol.append(float(np.max(g @ beta_path - h)))
+        if nonneg:
+            viol.append(float(np.max(-beta_path)))
 
     err = np.array(errors)
-    print(f"regression              : {N_OBS} x {N_FEATURES}, {N_GROUPS} group caps G beta <= h")
-    print(f"breakpoints             : {len(lasso.path)}")
-    print(f"segment midpoints tested: {err.size}")
-    print(f"midpoints with cap active: {active_mid} / {err.size}")
-    print(f"max |beta_path - beta_QP|: {err.max():.2e}")
-    print(f"max constraint violation : {max(violations):.2e}")
-    verdict = "EXACT (matches constrained QP to solver tolerance)" if err.max() < 1e-5 else "MISMATCH"
-    print(f"verdict                 : {verdict}")
+    print(f"\n{label}")
+    print(f"  breakpoints             : {len(lasso.path)}")
+    print(f"  segment midpoints tested: {err.size}")
+    if viol:
+        print(f"  max constraint violation: {max(viol):.2e}")
+    print(f"  max |beta_path - beta_QP|: {err.max():.2e}")
+    return err.max()
+
+
+def main() -> None:
+    """Run the inequality and non-negative scenarios and report exactness."""
+    rng = np.random.default_rng(SEED)
+    x, y = make_regression(rng)
+
+    # Scenario 1: per-group exposure caps G beta <= h that bind along the path.
+    group = np.arange(N_FEATURES) % N_GROUPS
+    g = np.array([(group == j).astype(float) for j in range(N_GROUPS)])
+    h = np.maximum(np.abs(g @ np.linalg.lstsq(x, y, rcond=None)[0]) * 0.4, 0.1)
+    err_ineq = validate("Scenario 1 -- inequality caps (G beta <= h)", Lasso(x=x, y=y, g=g, h=h), g=g, h=h)
+
+    # Scenario 2: the non-negative LASSO (beta >= 0).
+    err_nn = validate("Scenario 2 -- non-negative (beta >= 0)", Lasso(x=x, y=y, nonneg=True), nonneg=True)
+
+    worst = max(err_ineq, err_nn)
+    verdict = "EXACT (matches constrained QP to solver tolerance)" if worst < 1e-5 else "MISMATCH"
+    print(f"\nworst |beta_path - beta_QP| across scenarios: {worst:.2e}  ->  {verdict}")
 
 
 if __name__ == "__main__":

--- a/experiments/validate_lasso_constraints.py
+++ b/experiments/validate_lasso_constraints.py
@@ -1,0 +1,109 @@
+"""Validate the constrained LASSO path against a per-lambda general QP solver.
+
+``cvxcla.Lasso`` traces the LASSO regularisation path through the same parametric
+active-set engine as the Critical Line Algorithm, and -- like the CLA -- it now
+admits general linear inequality constraints ``G beta <= h`` (with ``h > 0``, so the
+path starts from the feasible ``beta = 0``). This script checks that claim the same
+way ``validate_constraints.py`` checks the constrained frontier: it traces a
+constrained path and re-solves every segment midpoint as a general QP.
+
+For a deterministic standardised regression with a group-exposure cap ``G beta <= h``
+we
+
+  (a) trace the constrained path with ``cvxcla.Lasso``, and
+  (b) at the midpoint ``lambda`` of every finite segment read the path coefficients
+      and re-solve
+
+          min  1/2 ||y - X beta||^2 + lambda ||beta||_1   s.t.  G beta <= h
+
+      from scratch with CVXPY / Clarabel (tight tolerances),
+
+and report the maximum coefficient discrepancy and the worst constraint violation.
+Agreement to solver tolerance, with the cap active along the path, confirms the
+constrained homotopy traces the exact constrained LASSO, not an approximation.
+
+Usage:
+    uv run --with cvxpy python experiments/validate_lasso_constraints.py
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+import cvxpy as cp
+import numpy as np
+
+from cvxcla import Lasso
+
+N_OBS = 60
+N_FEATURES = 12
+N_GROUPS = 3
+SEED = 5
+
+
+def make_regression(rng: np.random.Generator) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return (X, y, G, h): a standardised regression with binding group caps.
+
+    ``G`` sums the coefficients within each of ``N_GROUPS`` contiguous groups, and
+    ``h`` caps each group sum below its unconstrained least-squares level so the cap
+    genuinely binds along the path. ``h > 0`` keeps ``beta = 0`` feasible.
+    """
+    x = rng.standard_normal((N_OBS, N_FEATURES))
+    x = (x - x.mean(0)) / x.std(0)  # standardise columns
+    beta_true = rng.standard_normal(N_FEATURES)
+    y = x @ beta_true + 0.1 * rng.standard_normal(N_OBS)
+    y = y - y.mean()
+
+    group = np.arange(N_FEATURES) % N_GROUPS
+    g = np.array([(group == j).astype(float) for j in range(N_GROUPS)])
+    beta_ols = np.linalg.lstsq(x, y, rcond=None)[0]
+    # cap each group sum at a positive fraction of its (absolute) OLS level
+    h = np.maximum(np.abs(g @ beta_ols) * 0.4, 0.1)
+    return x, y, g, h
+
+
+def qp_solution(x: np.ndarray, y: np.ndarray, lam: float, g: np.ndarray, h: np.ndarray) -> np.ndarray:
+    """Solve the constrained LASSO at penalty ``lam`` with CVXPY / Clarabel."""
+    n = x.shape[1]
+    beta = cp.Variable(n)
+    objective = cp.Minimize(0.5 * cp.sum_squares(y - x @ beta) + lam * cp.norm1(beta))
+    cp.Problem(objective, [g @ beta <= h]).solve(
+        solver=cp.CLARABEL, tol_gap_abs=1e-12, tol_gap_rel=1e-12, tol_feas=1e-12
+    )
+    return np.asarray(beta.value, dtype=float)
+
+
+def main() -> None:
+    """Trace the constrained LASSO and check every segment midpoint against a QP."""
+    rng = np.random.default_rng(SEED)
+    x, y, g, h = make_regression(rng)
+    lasso = Lasso(x=x, y=y, g=g, h=h)
+
+    points = sorted(lasso.path, key=lambda bp: bp.lam)
+    errors = []
+    violations = []
+    active_mid = 0
+    for lo, hi in pairwise(points):
+        if hi.lam <= lasso.tol:
+            continue
+        lam = 0.5 * (lo.lam + hi.lam)
+        beta_path = lasso.solution(lam)
+        beta_qp = qp_solution(x, y, lam, g, h)
+        errors.append(float(np.max(np.abs(beta_path - beta_qp))))
+        violations.append(float(np.max(g @ beta_path - h)))
+        if np.any(g @ beta_path - h > -1e-7):
+            active_mid += 1
+
+    err = np.array(errors)
+    print(f"regression              : {N_OBS} x {N_FEATURES}, {N_GROUPS} group caps G beta <= h")
+    print(f"breakpoints             : {len(lasso.path)}")
+    print(f"segment midpoints tested: {err.size}")
+    print(f"midpoints with cap active: {active_mid} / {err.size}")
+    print(f"max |beta_path - beta_QP|: {err.max():.2e}")
+    print(f"max constraint violation : {max(violations):.2e}")
+    verdict = "EXACT (matches constrained QP to solver tolerance)" if err.max() < 1e-5 else "MISMATCH"
+    print(f"verdict                 : {verdict}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cvxcla/__init__.py
+++ b/src/cvxcla/__init__.py
@@ -11,7 +11,7 @@ methods to compute and analyze the efficient frontier.
 
 import importlib.metadata
 
-from .builder import ProblemBuilder
+from .builder import LassoBuilder, ProblemBuilder
 from .cla import CLA
 from .lasso import Lasso
 from .operators import (
@@ -32,6 +32,7 @@ __all__ = [
     "GramCovariance",
     "IncrementalDenseCovariance",
     "Lasso",
+    "LassoBuilder",
     "ParametricProblem",
     "ProblemBuilder",
     "QuadraticForm",

--- a/src/cvxcla/builder.py
+++ b/src/cvxcla/builder.py
@@ -32,6 +32,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .cla import CLA
+from .lasso import Lasso
 from .operators import QuadraticForm
 
 
@@ -234,3 +235,76 @@ class ProblemBuilder:
             g=g,
             h=h,
         )
+
+
+class LassoBuilder:
+    """Chainable builder for a LASSO regularisation-path problem.
+
+    The LASSO counterpart of :class:`ProblemBuilder`. Construct one via
+    :meth:`cvxcla.lasso.Lasso.problem`, optionally add inequality constraints with
+    :meth:`inequality`, and finish with :meth:`trace`, which builds the
+    :class:`cvxcla.lasso.Lasso` and traces the entire regularisation path. Like the
+    CLA builder it adds no modelling power: it accepts the same ``G beta <= h`` rows
+    the ``Lasso`` already supports and nothing else.
+
+    Examples:
+        >>> import numpy as np
+        >>> from cvxcla import Lasso
+        >>> rng = np.random.default_rng(0)
+        >>> x = rng.standard_normal((30, 5))
+        >>> y = rng.standard_normal(30)
+        >>> lasso = Lasso.problem(x, y).trace()
+        >>> len(lasso.path) > 0
+        True
+    """
+
+    def __init__(self, x: NDArray[np.float64], y: NDArray[np.float64]) -> None:
+        """Start a builder for design matrix ``x`` and response ``y``.
+
+        Args:
+            x: Design matrix of shape ``(m, n)``.
+            y: Response vector of shape ``(m,)``.
+        """
+        self.x = np.asarray(x, dtype=np.float64)
+        self.y = np.asarray(y, dtype=np.float64)
+        self._g_blocks: list[NDArray[np.float64]] = []
+        self._h_blocks: list[NDArray[np.float64]] = []
+
+    def inequality(self, g: NDArray[np.float64], h: float | NDArray[np.float64]) -> LassoBuilder:
+        """Add one or more inequality rows ``G beta <= h`` (repeated calls accumulate).
+
+        Args:
+            g: A length-``n`` row vector or a ``(p, n)`` matrix.
+            h: The matching right-hand side: a scalar for a single row, or a
+                length-``p`` vector. Each entry must be strictly positive (so
+                ``beta = 0`` stays feasible), checked when the path is traced.
+
+        Returns:
+            ``self``, for chaining.
+
+        Raises:
+            ValueError: If ``g``'s column count is not ``n`` or ``h``'s length does
+                not match the rows of ``g``.
+        """
+        g_block = np.atleast_2d(np.asarray(g, dtype=np.float64))
+        h_block = np.atleast_1d(np.asarray(h, dtype=np.float64))
+        if self.x.ndim == 2 and g_block.shape[1] != self.x.shape[1]:
+            msg = f"inequality: coefficient matrix must have {self.x.shape[1]} columns, got shape {g_block.shape}"
+            raise ValueError(msg)
+        if h_block.shape[0] != g_block.shape[0]:
+            msg = f"inequality: h must have {g_block.shape[0]} entries to match the rows, got {h_block.shape[0]}"
+            raise ValueError(msg)
+        self._g_blocks.append(g_block)
+        self._h_blocks.append(h_block)
+        return self
+
+    def trace(self) -> Lasso:
+        """Assemble the pieces, build the ``Lasso``, and trace the full path.
+
+        Returns:
+            The traced :class:`cvxcla.lasso.Lasso`, whose ``path`` holds the
+            breakpoints of the (constrained) regularisation path.
+        """
+        g = np.vstack(self._g_blocks) if self._g_blocks else None
+        h = np.concatenate(self._h_blocks) if self._h_blocks else None
+        return Lasso(x=self.x, y=self.y, g=g, h=h)

--- a/src/cvxcla/builder.py
+++ b/src/cvxcla/builder.py
@@ -269,6 +269,20 @@ class LassoBuilder:
         self.y = np.asarray(y, dtype=np.float64)
         self._g_blocks: list[NDArray[np.float64]] = []
         self._h_blocks: list[NDArray[np.float64]] = []
+        self._nonneg = False
+
+    def non_negative(self) -> LassoBuilder:
+        """Restrict the coefficients to ``beta >= 0`` (the non-negative LASSO).
+
+        Under ``beta >= 0`` the l1 penalty collapses to the linear term
+        ``lam * sum(beta)``, so the path is the standard one restricted to positive
+        signs -- structurally the CLA's box-bounded parametric QP.
+
+        Returns:
+            ``self``, for chaining.
+        """
+        self._nonneg = True
+        return self
 
     def inequality(self, g: NDArray[np.float64], h: float | NDArray[np.float64]) -> LassoBuilder:
         """Add one or more inequality rows ``G beta <= h`` (repeated calls accumulate).
@@ -307,4 +321,4 @@ class LassoBuilder:
         """
         g = np.vstack(self._g_blocks) if self._g_blocks else None
         h = np.concatenate(self._h_blocks) if self._h_blocks else None
-        return Lasso(x=self.x, y=self.y, g=g, h=h)
+        return Lasso(x=self.x, y=self.y, g=g, h=h, nonneg=self._nonneg)

--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -132,6 +132,7 @@ class Lasso:
     y: NDArray[np.float64]
     g: NDArray[np.float64] | None = None
     h: NDArray[np.float64] | None = None
+    nonneg: bool = False  # pragma: no mutate
     tol: float = 1e-9  # pragma: no mutate
     path: list[Breakpoint] = field(default_factory=list)
 
@@ -224,25 +225,35 @@ class Lasso:
         return float(np.max(np.abs(self.xty)))
 
     def begin(self) -> tuple[float, _LassoState]:
-        """Record the all-zero solution at ``lam_max`` and enter the first coordinate.
+        """Record the all-zero solution at the start penalty and enter the first coordinate.
 
-        Returns:
-            ``(lam_max, state)`` where ``state`` already has the most-correlated
-            coordinate in the active set and no inequality rows active, mirroring
-            the CLA's first turning point.
+        For the plain or inequality-constrained LASSO the start is
+        ``lam_max = ||X^T y||_inf`` and the most-correlated coordinate enters with its
+        sign. Under the non-negative restriction ``beta >= 0`` the l1 penalty becomes
+        the linear term ``lam * 1^T beta``, only positive correlations can enter, so
+        the start is ``lam_max = max_j (X^T y)_j`` and the coordinate enters with sign
+        ``+``. When no coordinate can enter (e.g. every correlation is non-positive
+        under ``beta >= 0``), ``beta = 0`` is optimal for all ``lambda`` and the path
+        is the single point.
         """
         n = self.dimension
         xty = self.xty
-        lam_max = self.lam_max
-        j0 = int(np.argmax(np.abs(xty)))
-        self.path.append(Breakpoint(lam_max, np.zeros(n), np.zeros(n, dtype=bool)))
-
-        active = np.zeros(n, dtype=bool)
-        active[j0] = True
-        signs = np.zeros(n)
-        signs[j0] = np.sign(xty[j0])
         rows_active = np.zeros(self.g_matrix.shape[0], dtype=bool)
-        return lam_max, _LassoState(active, signs, rows_active, lam_max)
+        if self.nonneg:
+            lam_max = float(np.max(xty)) if n else 0.0
+            j0, s0 = int(np.argmax(xty)), 1.0
+        else:
+            lam_max = self.lam_max
+            j0 = int(np.argmax(np.abs(xty)))
+            s0 = float(np.sign(xty[j0]))
+
+        self.path.append(Breakpoint(max(lam_max, 0.0), np.zeros(n), np.zeros(n, dtype=bool)))
+        active = np.zeros(n, dtype=bool)
+        signs = np.zeros(n)
+        if lam_max > self.tol:
+            active[j0] = True
+            signs[j0] = s0
+        return max(lam_max, 0.0), _LassoState(active, signs, rows_active, max(lam_max, 0.0))
 
     def segment(self, state: _LassoState) -> _LassoSegment:
         """Solve the affine segment for the current support, signs, and active rows.
@@ -261,6 +272,10 @@ class Lasso:
 
         xty_s = xty[active]
         signs_s = signs[active]
+        if not np.any(active):
+            # Empty support (e.g. the non-negative path when no correlation is
+            # positive): beta = 0, correlation = X^T y, and there is nothing to solve.
+            return _LassoSegment(alpha, beta_slope, xty.copy(), np.zeros(n), eta_alpha, eta_slope)
         if not np.any(rows_active):
             # Plain LASSO solve: beta_S(lam) = H_SS^{-1}(xty_S - lam s_S).
             alpha[active] = self.quad.solve_free(active, xty_s)
@@ -315,10 +330,12 @@ class Lasso:
         enters_pos = inactive & (np.abs(denom_pos) > self.tol)  # pragma: no mutate
         l_mat[:n][enters_pos, 1] = p[enters_pos] / denom_pos[enters_pos]
 
-        # enter (-): p_j + lam q_j = -lam -> lam = -p_j / (1 + q_j)
-        denom_neg = 1.0 + q
-        enters_neg = inactive & (np.abs(denom_neg) > self.tol)  # pragma: no mutate
-        l_mat[:n][enters_neg, 2] = -p[enters_neg] / denom_neg[enters_neg]
+        # enter (-): p_j + lam q_j = -lam -> lam = -p_j / (1 + q_j). Disabled under the
+        # non-negative restriction beta >= 0, where only positive entries are allowed.
+        if not self.nonneg:
+            denom_neg = 1.0 + q
+            enters_neg = inactive & (np.abs(denom_neg) > self.tol)  # pragma: no mutate
+            l_mat[:n][enters_neg, 2] = -p[enters_neg] / denom_neg[enters_neg]
 
         if rows:
             g_mat = self.g_matrix

--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -22,18 +22,30 @@ it. The role played by the covariance ``Sigma`` and mean ``mu`` in the CLA is
 played here by the Gram matrix ``H = X^T X`` (wrapped in ``DenseCovariance``) and
 the vector ``X^T y``.
 
-Two coordinate-indexed event families, mirroring the CLA's "move to / leave a
-bound":
+**Constraints.** Like the CLA, the path tracer admits general linear inequality
+constraints ``G beta <= h``. An active row enters the reduced KKT system exactly as
+in the CLA (the bordered Schur complement of ``cla.py``), and the generalised
+correlation that drives the enter/leave events carries the active-row multipliers,
+``correlation(lam) = X^T y - H beta(lam) - G_S^T eta(lam)``. The constrained path is
+still piecewise linear (a quadratic loss under a polyhedral penalty *and* polyhedral
+constraints; cf. Rosset and Zhu). We require ``h > 0`` so the path can start from
+``beta = 0`` with every row slack -- the same first vertex as the unconstrained
+LASSO. (Equality constraints, or ``h`` with a zero entry, need a feasibility seed
+analogous to the CLA's linear-programming first vertex, and are left to future work.)
+
+Event families, mirroring the CLA's "move to / leave a bound":
 
 * **leave** -- an active coefficient reaches zero: ``lam = alpha_j / beta_slope_j``.
-* **enter** -- an inactive correlation reaches ``+/-lam``: ``p_j + lam q_j = +/-lam``.
+* **enter** -- an inactive (generalised) correlation reaches ``+/-lam``.
+* **activate** -- a slack inequality row's residual ``G_r beta - h_r`` reaches zero.
+* **release** -- an active row's multiplier ``eta_r`` reaches zero.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from itertools import pairwise
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -41,9 +53,12 @@ from numpy.typing import NDArray
 from .operators import DenseCovariance, QuadraticForm
 from .pathtracer import trace
 
+if TYPE_CHECKING:
+    from .builder import LassoBuilder
+
 
 class _LassoState(NamedTuple):
-    """The active set, sign pattern, and current penalty defining the segment.
+    """The support, sign pattern, active inequality rows, and current penalty.
 
     ``lam`` is the penalty at the segment's upper end. The event scan uses it to
     require *strict* progress to a smaller penalty: right after a coefficient
@@ -54,16 +69,24 @@ class _LassoState(NamedTuple):
 
     active: NDArray[np.bool_]
     signs: NDArray[np.float64]
+    rows_active: NDArray[np.bool_]
     lam: float
 
 
 class _LassoSegment(NamedTuple):
-    """The affine path ``beta(lam) = alpha - lam * beta_slope`` and correlation ``p + lam * q``."""
+    """The affine path ``beta(lam) = alpha - lam * beta_slope`` and its multipliers.
+
+    ``eta_alpha``/``eta_slope`` give the active-row multiplier path
+    ``eta(lam) = eta_alpha + lam * eta_slope`` (length ``p``, nonzero only on active
+    rows); ``p``/``q`` give the generalised correlation ``p + lam * q``.
+    """
 
     alpha: NDArray[np.float64]
     beta_slope: NDArray[np.float64]
     p: NDArray[np.float64]
     q: NDArray[np.float64]
+    eta_alpha: NDArray[np.float64]
+    eta_slope: NDArray[np.float64]
 
 
 @dataclass(frozen=True)
@@ -87,19 +110,28 @@ class Lasso:
     """The LASSO regularisation path, traced as a parametric active-set problem.
 
     Constructing a ``Lasso`` traces the entire path from ``lam_max`` (where
-    ``beta = 0``) down to ``lam = 0`` (the ordinary least-squares fit on the final
-    support), storing the breakpoints in ``path``. The walk is driven by the same
-    ``cvxcla.pathtracer.trace`` loop as the Critical Line Algorithm.
+    ``beta = 0``) down to ``lam = 0`` (the least-squares fit on the final support,
+    subject to any active constraints), storing the breakpoints in ``path``. The
+    walk is driven by the same ``cvxcla.pathtracer.trace`` loop as the Critical Line
+    Algorithm.
+
+    Optional linear inequality constraints ``G beta <= h`` (with ``h > 0``) are
+    traced through the same bordered solve as the CLA's ``G w <= h`` rows.
 
     Attributes:
         x: Design matrix of shape ``(m, n)``.
         y: Response vector of shape ``(m,)``.
+        g: Optional inequality matrix ``(p, n)`` of ``G beta <= h``; ``None`` means
+            the plain LASSO.
+        h: Optional inequality right-hand side ``(p,)``; must be strictly positive.
         tol: Tolerance for event selection and the validity window.
         path: The discovered breakpoints, populated on construction.
     """
 
     x: NDArray[np.float64]
     y: NDArray[np.float64]
+    g: NDArray[np.float64] | None = None
+    h: NDArray[np.float64] | None = None
     tol: float = 1e-9  # pragma: no mutate
     path: list[Breakpoint] = field(default_factory=list)
 
@@ -107,8 +139,9 @@ class Lasso:
         """Validate shapes and trace the full LASSO path.
 
         Raises:
-            ValueError: If ``x`` is not 2d or ``y``'s length does not match the
-                number of rows of ``x``.
+            ValueError: If ``x`` is not 2d, ``y``'s length does not match ``x``, the
+                constraint shapes are inconsistent, or any ``h`` entry is not
+                strictly positive (which would make ``beta = 0`` infeasible).
         """
         if self.x.ndim != 2:
             msg = f"x must be a 2d design matrix, got shape {self.x.shape}"
@@ -116,7 +149,50 @@ class Lasso:
         if self.y.shape != (self.x.shape[0],):
             msg = f"y must have shape ({self.x.shape[0]},), got {self.y.shape}"
             raise ValueError(msg)
+        if self.g is not None or self.h is not None:
+            if self.g is None or self.h is None:
+                msg = "g and h must be provided together"
+                raise ValueError(msg)
+            if self.g.shape != (self.h.shape[0], self.dimension):
+                msg = f"g must have shape ({self.h.shape[0]}, {self.dimension}), got {self.g.shape}"
+                raise ValueError(msg)
+            if np.any(self.h <= self.tol):
+                msg = "h must be strictly positive so beta = 0 is feasible (equality/zero-h needs a feasibility seed)"
+                raise ValueError(msg)
         trace(self)
+
+    @classmethod
+    def problem(cls, x: NDArray[np.float64], y: NDArray[np.float64]) -> LassoBuilder:
+        """Start a fluent :class:`cvxcla.builder.LassoBuilder` for a LASSO path.
+
+        The LASSO counterpart of :meth:`cvxcla.cla.CLA.problem`: chain
+        ``.inequality(G, h)`` and finish with ``.trace()``. The builder maps onto the
+        constructor arguments and adds no modelling power.
+
+        Args:
+            x: Design matrix of shape ``(m, n)``.
+            y: Response vector of shape ``(m,)``.
+
+        Returns:
+            A :class:`cvxcla.builder.LassoBuilder`.
+        """
+        from .builder import LassoBuilder
+
+        return LassoBuilder(x, y)
+
+    @property
+    def g_matrix(self) -> NDArray[np.float64]:
+        """Inequality matrix ``G`` as a ``(p, n)`` array (empty ``(0, n)`` if none)."""
+        if self.g is None:
+            return np.zeros((0, self.dimension))
+        return np.atleast_2d(self.g)
+
+    @property
+    def h_vector(self) -> NDArray[np.float64]:
+        """Inequality right-hand side ``h`` as a ``(p,)`` array (empty if none)."""
+        if self.h is None:
+            return np.zeros(0)
+        return np.atleast_1d(self.h)
 
     @property
     def quad(self) -> QuadraticForm:
@@ -134,8 +210,17 @@ class Lasso:
         return int(self.x.shape[1])
 
     @property
+    def event_dimension(self) -> int:
+        """Coordinate count for the path-length cap: ``n`` features + ``p`` rows."""
+        return self.dimension + int(self.g_matrix.shape[0])
+
+    @property
     def lam_max(self) -> float:
-        """The smallest penalty at which ``beta = 0`` is optimal: ``||X^T y||_inf``."""
+        """The smallest penalty at which ``beta = 0`` is optimal: ``||X^T y||_inf``.
+
+        With ``h > 0`` every inequality row is slack at ``beta = 0`` (zero
+        multiplier), so the unconstrained threshold is unchanged.
+        """
         return float(np.max(np.abs(self.xty)))
 
     def begin(self) -> tuple[float, _LassoState]:
@@ -143,7 +228,8 @@ class Lasso:
 
         Returns:
             ``(lam_max, state)`` where ``state`` already has the most-correlated
-            coordinate in the active set, mirroring the CLA's first turning point.
+            coordinate in the active set and no inequality rows active, mirroring
+            the CLA's first turning point.
         """
         n = self.dimension
         xty = self.xty
@@ -155,80 +241,127 @@ class Lasso:
         active[j0] = True
         signs = np.zeros(n)
         signs[j0] = np.sign(xty[j0])
-        return lam_max, _LassoState(active, signs, lam_max)
+        rows_active = np.zeros(self.g_matrix.shape[0], dtype=bool)
+        return lam_max, _LassoState(active, signs, rows_active, lam_max)
 
     def segment(self, state: _LassoState) -> _LassoSegment:
-        """Solve the affine segment for the current ``(active, signs)`` state.
+        """Solve the affine segment for the current support, signs, and active rows.
 
-        Both solves go through the ``QuadraticForm`` principal-submatrix solver,
-        exactly as the CLA solves against the free covariance block.
+        With no active rows this is the plain LASSO solve against the Gram
+        submatrix. With active rows it is the bordered Schur solve of the CLA: the
+        active rows ``G_S`` enter the reduced KKT system as extra equality rows.
         """
         n = self.dimension
-        active, signs = state.active, state.signs
+        active, signs, rows_active = state.active, state.signs, state.rows_active
+        xty = self.xty
         alpha = np.zeros(n)
         beta_slope = np.zeros(n)
-        alpha[active] = self.quad.solve_free(active, self.xty[active])
-        beta_slope[active] = self.quad.solve_free(active, signs[active])
+        eta_alpha = np.zeros(self.g_matrix.shape[0])
+        eta_slope = np.zeros(self.g_matrix.shape[0])
 
-        # correlation(lam) = X^T y - H beta(lam) = (xty - H alpha) + lam (H beta_slope)
-        p = self.xty - self.quad.matvec(alpha)
-        q = self.quad.matvec(beta_slope)
-        return _LassoSegment(alpha, beta_slope, p, q)
+        xty_s = xty[active]
+        signs_s = signs[active]
+        if not np.any(rows_active):
+            # Plain LASSO solve: beta_S(lam) = H_SS^{-1}(xty_S - lam s_S).
+            alpha[active] = self.quad.solve_free(active, xty_s)
+            beta_slope[active] = self.quad.solve_free(active, signs_s)
+        else:
+            # Bordered solve over (beta_S, eta_R): the active rows G_RS act as
+            # equality rows, exactly the CLA's Schur complement (cla.py).
+            g_rs = self.g_matrix[np.ix_(rows_active, active)]  # |R| x |S|
+            h_r = self.h_vector[rows_active]
+            rhs = np.column_stack([xty_s, signs_s, g_rs.T])  # |S| x (2 + |R|)
+            sol = self.quad.solve_free(active, rhs)
+            u0, u1, big_y = sol[:, 0], sol[:, 1], sol[:, 2:]  # big_y = H_SS^{-1} G_RS^T
+            schur = g_rs @ big_y  # |R| x |R|
+            eta_a = np.linalg.solve(schur, g_rs @ u0 - h_r)
+            eta_s = -np.linalg.solve(schur, g_rs @ u1)
+            alpha[active] = u0 - big_y @ eta_a
+            beta_slope[active] = u1 + big_y @ eta_s
+            eta_alpha[rows_active] = eta_a
+            eta_slope[rows_active] = eta_s
+
+        # Generalised correlation c(lam) = xty - H beta(lam) - G_R^T eta(lam) = p + lam q.
+        g_r = self.g_matrix[rows_active]
+        eta_a_r = eta_alpha[rows_active]
+        eta_s_r = eta_slope[rows_active]
+        p = xty - self.quad.matvec(alpha) - g_r.T @ eta_a_r
+        q = self.quad.matvec(beta_slope) - g_r.T @ eta_s_r
+        return _LassoSegment(alpha, beta_slope, p, q, eta_alpha, eta_slope)
 
     def event_matrix(self, state: _LassoState, segment: _LassoSegment) -> NDArray[np.float64]:
-        """Return the ``(n, 3)`` matrix of candidate critical lambdas.
+        """Return the ``(n + p, 4)`` matrix of candidate critical lambdas.
 
-        Columns: 0 = leave (active coefficient hits zero), 1 = enter with sign
-        ``+1`` (inactive correlation reaches ``+lam``), 2 = enter with sign ``-1``
-        (reaches ``-lam``). Only events strictly above ``tol`` are kept, so the
-        trace stops cleanly as ``lam`` approaches zero.
+        Rows ``0..n-1`` are coordinate events (col 0 leave, col 1 enter ``+``, col 2
+        enter ``-``); rows ``n..n+p-1`` are inequality-row events (col 0 activate, col
+        1 release). Entries are ``-inf`` where the event cannot occur, and only
+        events strictly inside ``(tol, lam - tol)`` are kept.
         """
         n = self.dimension
+        rows = self.g_matrix.shape[0]
         active = state.active
         inactive = ~active
-        alpha, beta_slope, p, q = segment
+        alpha, beta_slope, p, q, eta_alpha, eta_slope = segment
+        rows_active = state.rows_active
 
-        l_mat = np.full((n, 3), -np.inf)
+        l_mat = np.full((n + rows, 4), -np.inf)
 
         # leave: alpha_j - lam beta_slope_j = 0
         leaves = active & (np.abs(beta_slope) > self.tol)  # pragma: no mutate
-        l_mat[leaves, 0] = alpha[leaves] / beta_slope[leaves]
+        l_mat[:n][leaves, 0] = alpha[leaves] / beta_slope[leaves]
 
         # enter (+): p_j + lam q_j = +lam -> lam = p_j / (1 - q_j)
         denom_pos = 1.0 - q
         enters_pos = inactive & (np.abs(denom_pos) > self.tol)  # pragma: no mutate
-        l_mat[enters_pos, 1] = p[enters_pos] / denom_pos[enters_pos]
+        l_mat[:n][enters_pos, 1] = p[enters_pos] / denom_pos[enters_pos]
 
         # enter (-): p_j + lam q_j = -lam -> lam = -p_j / (1 + q_j)
         denom_neg = 1.0 + q
         enters_neg = inactive & (np.abs(denom_neg) > self.tol)  # pragma: no mutate
-        l_mat[enters_neg, 2] = -p[enters_neg] / denom_neg[enters_neg]
+        l_mat[:n][enters_neg, 2] = -p[enters_neg] / denom_neg[enters_neg]
 
-        # Keep only events that make strict progress to a smaller, positive penalty:
-        # at or above the current lam they are the spurious inverse of the coordinate
-        # just flipped (which would cycle); at or below ~0 the path is complete.
+        if rows:
+            g_mat = self.g_matrix
+            slope_row = g_mat @ beta_slope  # d/d(-lam) of the row value
+            level_row = g_mat @ alpha - self.h_vector  # G_r alpha - h_r
+            # activate: the row value G_r beta(lam) = level + h_r - lam slope rises to
+            # the cap h_r as lam decreases when its slope d(value)/d(-lam) = slope_row
+            # is positive; the crossing is lam = (G_r alpha - h_r) / (G_r beta_slope).
+            inactive_rows = ~rows_active & (slope_row > self.tol)  # pragma: no mutate
+            l_mat[n:][inactive_rows, 0] = level_row[inactive_rows] / slope_row[inactive_rows]
+            # release: eta_r(lam) = eta_alpha + lam eta_slope -> 0 from eta > 0, i.e. eta_slope > 0.
+            releasing = rows_active & (eta_slope > self.tol)  # pragma: no mutate
+            l_mat[n:][releasing, 1] = -eta_alpha[releasing] / eta_slope[releasing]
+
+        # Keep only events that make strict progress to a smaller, positive penalty.
         l_mat[(l_mat <= self.tol) | (l_mat >= state.lam - self.tol)] = -np.inf
         return l_mat
 
     def step(self, state: _LassoState, segment: _LassoSegment, sec: int, direction: int, lam: float) -> _LassoState:
-        """Record the breakpoint at ``lam`` after flipping coordinate ``sec``.
+        """Record the breakpoint at ``lam`` after flipping coordinate or row ``sec``.
 
-        ``direction`` 0 removes ``sec`` from the support; 1/2 add it with sign
-        ``+1``/``-1``. The recorded coefficients are the old segment evaluated at
-        ``lam`` (the path is continuous across the flip).
+        For a coordinate (``sec < n``): direction 0 removes it from the support, 1/2
+        add it with sign ``+1``/``-1``. For an inequality row (``sec >= n``):
+        direction 0 activates the row, 1 releases it. The path is continuous across
+        the flip, so the recorded coefficients are the old segment at ``lam``.
         """
+        n = self.dimension
         active = state.active.copy()
         signs = state.signs.copy()
-        if direction == 0:
-            active[sec] = False
-            signs[sec] = 0.0
+        rows_active = state.rows_active.copy()
+        if sec < n:
+            if direction == 0:
+                active[sec] = False
+                signs[sec] = 0.0
+            else:
+                active[sec] = True
+                signs[sec] = 1.0 if direction == 1 else -1.0
         else:
-            active[sec] = True
-            signs[sec] = 1.0 if direction == 1 else -1.0
+            rows_active[sec - n] = direction == 0
 
         beta = segment.alpha - lam * segment.beta_slope
         self.path.append(Breakpoint(lam, beta, active.copy()))
-        return _LassoState(active, signs, lam)
+        return _LassoState(active, signs, rows_active, lam)
 
     def finish(self, state: _LassoState, segment: _LassoSegment) -> None:
         """Record the ``lam = 0`` endpoint: the least-squares fit on the final support."""

--- a/tests/test_lasso.py
+++ b/tests/test_lasso.py
@@ -142,6 +142,103 @@ class TestLassoValidation:
             Lasso(np.ones((5, 3)), np.ones(4))
 
 
+class TestConstrainedLasso:
+    """The LASSO path under linear inequality constraints ``G beta <= h``."""
+
+    @staticmethod
+    def _problem_with_caps():
+        """A standardised regression with group-sum caps that bind along the path."""
+        rng = np.random.default_rng(1)
+        m, n = 50, 10
+        x = rng.standard_normal((m, n))
+        x = (x - x.mean(0)) / x.std(0)
+        beta = rng.standard_normal(n)
+        y = x @ beta + 0.1 * rng.standard_normal(m)
+        y = y - y.mean()
+        group = np.arange(n) % 3
+        g = np.array([(group == j).astype(float) for j in range(3)])
+        beta_ols = np.linalg.lstsq(x, y, rcond=None)[0]
+        h = np.maximum(np.abs(g @ beta_ols) * 0.4, 0.1)
+        return x, y, g, h
+
+    def test_path_is_feasible(self):
+        """Every breakpoint satisfies the inequality constraints."""
+        x, y, g, h = self._problem_with_caps()
+        lasso = Lasso(x=x, y=y, g=g, h=h)
+        for bp in lasso.path:
+            assert np.all(g @ bp.beta <= h + 1e-7)
+
+    def test_cap_binds(self):
+        """At least one breakpoint holds a constraint row active (the cap bites)."""
+        x, y, g, h = self._problem_with_caps()
+        lasso = Lasso(x=x, y=y, g=g, h=h)
+        assert any(np.any(np.abs(g @ bp.beta - h) <= 1e-7) for bp in lasso.path), "expected a binding cap"
+
+    def test_loose_caps_match_unconstrained(self):
+        """With caps too loose to bind, the constrained path equals the plain LASSO."""
+        x, y, g, _ = self._problem_with_caps()
+        constrained = Lasso(x=x, y=y, g=g, h=np.full(g.shape[0], 1e6))
+        plain = Lasso(x=x, y=y)
+        for frac in (0.8, 0.5, 0.2):
+            lam = frac * plain.lam_max
+            np.testing.assert_allclose(constrained.solution(lam), plain.solution(lam), atol=1e-7)
+
+    def test_rejects_nonpositive_h(self):
+        """A non-positive ``h`` entry (``beta = 0`` infeasible) is rejected."""
+        x, y, g, h = self._problem_with_caps()
+        h[0] = 0.0
+        with pytest.raises(ValueError, match="strictly positive"):
+            Lasso(x=x, y=y, g=g, h=h)
+
+    def test_rejects_g_without_h(self):
+        """Providing ``g`` without ``h`` is rejected."""
+        x, y, g, _ = self._problem_with_caps()
+        with pytest.raises(ValueError, match="together"):
+            Lasso(x=x, y=y, g=g)
+
+    def test_rejects_bad_g_shape(self):
+        """A ``g`` whose column count is not ``n`` is rejected."""
+        x, y, g, h = self._problem_with_caps()
+        with pytest.raises(ValueError, match="g must have shape"):
+            Lasso(x=x, y=y, g=g[:, :-1], h=h)
+
+
+class TestLassoBuilder:
+    """The fluent ``Lasso.problem(...).trace()`` builder."""
+
+    def test_plain_builder_matches_constructor(self):
+        """``Lasso.problem(x, y).trace()`` equals the direct ``Lasso(x, y)``."""
+        x, y = _uncorrelated_problem()
+        built = Lasso.problem(x, y).trace()
+        direct = Lasso(x=x, y=y)
+        assert len(built.path) == len(direct.path)
+        for frac in (0.8, 0.4, 0.1):
+            lam = frac * direct.lam_max
+            np.testing.assert_allclose(built.solution(lam), direct.solution(lam), atol=1e-12)
+
+    def test_inequality_builder_matches_constructor(self):
+        """The builder's ``.inequality(g, h)`` equals passing ``g, h`` directly."""
+        x, y, g, h = TestConstrainedLasso._problem_with_caps()
+        built = Lasso.problem(x, y).inequality(g, h).trace()
+        direct = Lasso(x=x, y=y, g=g, h=h)
+        assert len(built.path) == len(direct.path)
+        for bp in built.path:
+            assert np.all(g @ bp.beta <= h + 1e-7)
+
+    def test_inequality_accumulates_rows(self):
+        """Repeated ``.inequality`` calls stack rows, like the CLA builder."""
+        x, y, g, h = TestConstrainedLasso._problem_with_caps()
+        stacked = Lasso.problem(x, y).inequality(g[:1], h[:1]).inequality(g[1:], h[1:]).trace()
+        direct = Lasso(x=x, y=y, g=g, h=h)
+        assert len(stacked.path) == len(direct.path)
+
+    def test_builder_rejects_bad_inequality_shape(self):
+        """A row vector of the wrong width is rejected at ``.inequality``."""
+        x, y, g, h = TestConstrainedLasso._problem_with_caps()
+        with pytest.raises(ValueError, match=r"must have .* columns"):
+            Lasso.problem(x, y).inequality(g[:, :-1], h)
+
+
 def test_breakpoint_is_frozen():
     """Breakpoint is an immutable record."""
     import dataclasses

--- a/tests/test_lasso.py
+++ b/tests/test_lasso.py
@@ -262,6 +262,16 @@ class TestNonNegativeLasso:
             lam = frac * direct.path[0].lam
             np.testing.assert_allclose(built.solution(lam), direct.solution(lam), atol=1e-12)
 
+    def test_all_nonpositive_correlations_give_zero_path(self):
+        """With no positive correlation, the non-negative path is identically zero."""
+        rng = np.random.default_rng(3)
+        x = np.abs(rng.standard_normal((30, 5))) + 0.1  # all-positive design
+        y = -x.sum(axis=1)  # so X^T y < 0 componentwise: nothing can enter
+        lasso = Lasso(x=x, y=y, nonneg=True)
+        for bp in lasso.path:
+            np.testing.assert_allclose(bp.beta, 0.0, atol=1e-9)
+        np.testing.assert_allclose(lasso.solution(0.0), 0.0, atol=1e-9)
+
 
 class TestLassoBuilder:
     """The fluent ``Lasso.problem(...).trace()`` builder."""
@@ -297,6 +307,20 @@ class TestLassoBuilder:
         x, y, g, h = TestConstrainedLasso._problem_with_caps()
         with pytest.raises(ValueError, match=r"must have .* columns"):
             Lasso.problem(x, y).inequality(g[:, :-1], h)
+
+    def test_builder_rejects_bad_inequality_h_length(self):
+        """An ``h`` whose length does not match the rows of ``g`` is rejected."""
+        x, y, g, h = TestConstrainedLasso._problem_with_caps()
+        with pytest.raises(ValueError, match="h must have"):
+            Lasso.problem(x, y).inequality(g, h[:-1])
+
+
+def test_constraint_accessors_empty_without_constraints():
+    """The g/h accessors return empty arrays when no inequality is supplied."""
+    x, y = _uncorrelated_problem()
+    lasso = Lasso(x=x, y=y)
+    assert lasso.h_vector.shape == (0,)
+    assert lasso.g_matrix.shape == (0, x.shape[1])
 
 
 def test_breakpoint_is_frozen():

--- a/tests/test_lasso.py
+++ b/tests/test_lasso.py
@@ -203,6 +203,66 @@ class TestConstrainedLasso:
             Lasso(x=x, y=y, g=g[:, :-1], h=h)
 
 
+def _nonneg_coordinate_descent(x: np.ndarray, y: np.ndarray, lam: float, iters: int = 5000) -> np.ndarray:
+    """An independent non-negative LASSO solver (coordinate descent, clamped at 0)."""
+    n = x.shape[1]
+    beta = np.zeros(n)
+    col_sq = np.sum(x * x, axis=0)
+    r = y - x @ beta
+    for _ in range(iters):
+        max_change = 0.0
+        for j in range(n):
+            if col_sq[j] == 0.0:
+                continue
+            rho = x[:, j] @ r + col_sq[j] * beta[j]
+            new = max(rho - lam, 0.0) / col_sq[j]  # soft-threshold then clamp at 0
+            if new != beta[j]:
+                r += x[:, j] * (beta[j] - new)
+                max_change = max(max_change, abs(new - beta[j]))
+                beta[j] = new
+        if max_change < 1e-12:
+            break
+    return beta
+
+
+class TestNonNegativeLasso:
+    """The LASSO path under the sign restriction ``beta >= 0``."""
+
+    def test_path_is_non_negative(self):
+        """Every breakpoint has non-negative coefficients."""
+        x, y = _uncorrelated_problem()
+        lasso = Lasso(x=x, y=y, nonneg=True)
+        for bp in lasso.path:
+            assert np.all(bp.beta >= -1e-9)
+
+    def test_matches_nonneg_coordinate_descent(self):
+        """Sampled along the path, beta matches an independent non-negative solver."""
+        x, y = _correlated_problem()
+        lasso = Lasso(x=x, y=y, nonneg=True)
+        for frac in (0.8, 0.5, 0.25, 0.05):
+            lam = frac * float(np.max(x.T @ y))
+            np.testing.assert_allclose(lasso.solution(lam), _nonneg_coordinate_descent(x, y, lam), atol=1e-5)
+
+    def test_suppresses_negative_coefficients(self):
+        """A coefficient the plain LASSO drives negative is held at zero here."""
+        x, y = _correlated_problem()
+        plain = Lasso(x=x, y=y)
+        nonneg = Lasso(x=x, y=y, nonneg=True)
+        lam = 0.2 * plain.lam_max
+        assert np.min(plain.solution(lam)) < -1e-6, "expected the plain path to go negative"
+        assert np.all(nonneg.solution(lam) >= -1e-9)
+
+    def test_builder_non_negative_matches_constructor(self):
+        """``.non_negative()`` on the builder equals ``nonneg=True`` directly."""
+        x, y = _uncorrelated_problem()
+        built = Lasso.problem(x, y).non_negative().trace()
+        direct = Lasso(x=x, y=y, nonneg=True)
+        assert len(built.path) == len(direct.path)
+        for frac in (0.8, 0.4, 0.1):
+            lam = frac * direct.path[0].lam
+            np.testing.assert_allclose(built.solution(lam), direct.solution(lam), atol=1e-12)
+
+
 class TestLassoBuilder:
     """The fluent ``Lasso.problem(...).trace()`` builder."""
 


### PR DESCRIPTION
Delivers the constrained LASSO and retitles the paper to match: **Exact Constrained Solution Paths for Portfolio Optimization and the LASSO**.

## LASSO via the shared engine
`cvxcla.Lasso` traces the LASSO path through the *same* parametric-active-set engine as the CLA, now with constraints:
- **Inequality** `G β ≤ h` (`h > 0`): active rows enter via the bordered Schur complement of §4.1; the generalised correlation carries the row multipliers; row activate/release events. Starts cleanly from `β = 0`.
- **Non-negative** `β ≥ 0`: under the sign restriction `‖β‖₁ = 1ᵀβ` becomes *linear*, so it's literally the CLA's box-bounded parametric QP — the path restricted to positive signs (enter only at `+λ`, seed from `argmax(Xᵀy)`).
- Unconstrained behaviour unchanged.

Equality `Aβ = b` was prototyped and **deliberately dropped**: the canonical case (sum-to-zero, `b=0`) can't be traced one coordinate at a time (needs a ± pair to enter together), and the budget-type equality degenerates the ℓ₁ penalty back into the CLA. Noted as future work.

## Fluent builder (parity with the CLA)
`Lasso.problem(x, y).inequality(G, h).trace()` and `.non_negative().trace()` — a `LassoBuilder` mirroring `ProblemBuilder`, exported from the package.

## Validation
- `experiments/validate_lasso_constraints.py`: inequality (~2×10⁻¹⁰) and non-negative (~3×10⁻¹¹) paths vs per-λ CVXPY/Clarabel QP, constraints satisfied to machine precision.
- `tests/test_lasso.py`: feasibility, binding, reduces-to-unconstrained, non-negativity, match to an independent non-negative coordinate descent, input validation, builder parity.
- Full suite **243 passed**; `ruff` + `mypy --strict` + `ty` clean; `pdflatex` 0 overfull / 0 undefined.

## Paper + README
- §11 subsection "A constrained LASSO through the same engine" (inequality + non-negative, with the ℓ₁→linear unification point) and a builder listing.
- Abstract broadened; title updated.
- **README**: Overview + Features now mention the LASSO; new "The LASSO through the same engine" usage section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)