### PR TITLE
refactor: share G≤h inequality normalization via an InequalityConstrained mixin

### DIFF
--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 from .first import first_vertex_lp, init_algo
 from .operators import DenseCovariance, QuadraticForm
-from .pathtracer import trace
+from .pathtracer import InequalityConstrained, trace
 from .types import Frontier, FrontierPoint, TurningPoint
 
 # A genuinely rank-deficient free block has a reciprocal condition number at
@@ -59,7 +59,7 @@ class _Segment(NamedTuple):
 
 
 @dataclass(frozen=True)
-class CLA:
+class CLA(InequalityConstrained):
     """Critical Line Algorithm implementation based on Markowitz's approach.
 
     This class implements the Critical Line Algorithm as described by Harry Markowitz
@@ -147,41 +147,10 @@ class CLA:
             return self.covariance
         return DenseCovariance(self.covariance)
 
-    @cached_property
-    def g_matrix(self) -> NDArray[np.float64]:
-        """Inequality matrix ``G`` of ``G w <= h`` as a ``(p, n)`` array.
-
-        ``None`` is normalised to an empty ``(0, n)`` matrix, so the inequality
-        machinery is a no-op and the trace reduces exactly to the equality-only
-        problem. This is the single point where the inequality input is
-        normalised, mirroring ``covariance_operator`` for the covariance.
-        """
-        if self.g is None:
-            return np.zeros((0, self.dimension))
-        return np.atleast_2d(np.asarray(self.g, dtype=np.float64))
-
-    @cached_property
-    def h_vector(self) -> NDArray[np.float64]:
-        """Inequality right-hand side ``h`` of ``G w <= h`` as a ``(p,)`` array."""
-        if self.h is None:
-            return np.zeros(0)
-        return np.atleast_1d(np.asarray(self.h, dtype=np.float64))
-
     @property
     def dimension(self) -> int:
         """Number of assets ``n`` (the problem dimension for the path tracer)."""
         return len(self.mean)
-
-    @property
-    def event_dimension(self) -> int:
-        """Coordinate count for the path-length safety cap: ``n`` bounds + ``p`` rows.
-
-        Each turning point fixes the activity of exactly one coordinate -- a box
-        bound, or an inequality row of ``G w <= h`` -- so the tracer's iteration cap
-        scales with ``n + p`` rather than ``n`` alone. With no inequality rows this
-        is just ``n``.
-        """
-        return self.dimension + int(self.g_matrix.shape[0])
 
     @cached_property
     def _free_blocks_well_conditioned(self) -> bool:

--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -52,7 +52,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .operators import DenseCovariance, GramCovariance, QuadraticForm
-from .pathtracer import trace
+from .pathtracer import InequalityConstrained, trace
 
 if TYPE_CHECKING:
     from .builder import LassoBuilder
@@ -107,7 +107,7 @@ class Breakpoint:
 
 
 @dataclass
-class Lasso:
+class Lasso(InequalityConstrained):
     """The LASSO regularisation path, traced as a parametric active-set problem.
 
     Constructing a ``Lasso`` traces the entire path from ``lam_max`` (where
@@ -183,20 +183,6 @@ class Lasso:
 
         return LassoBuilder(x, y)
 
-    @property
-    def g_matrix(self) -> NDArray[np.float64]:
-        """Inequality matrix ``G`` as a ``(p, n)`` array (empty ``(0, n)`` if none)."""
-        if self.g is None:
-            return np.zeros((0, self.dimension))
-        return np.atleast_2d(self.g)
-
-    @property
-    def h_vector(self) -> NDArray[np.float64]:
-        """Inequality right-hand side ``h`` as a ``(p,)`` array (empty if none)."""
-        if self.h is None:
-            return np.zeros(0)
-        return np.atleast_1d(self.h)
-
     @cached_property
     def quad(self) -> QuadraticForm:
         """The Gram matrix ``X^T X`` as a ``QuadraticForm`` backend (cached: ``X`` is fixed).
@@ -223,11 +209,6 @@ class Lasso:
     def dimension(self) -> int:
         """Number of features ``n`` (the problem dimension for the path tracer)."""
         return int(self.x.shape[1])
-
-    @property
-    def event_dimension(self) -> int:
-        """Coordinate count for the path-length cap: ``n`` features + ``p`` rows."""
-        return self.dimension + int(self.g_matrix.shape[0])
 
     @property
     def lam_max(self) -> float:

--- a/src/cvxcla/pathtracer.py
+++ b/src/cvxcla/pathtracer.py
@@ -23,6 +23,7 @@ by the same ``trace`` here.
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
@@ -78,6 +79,55 @@ class ParametricProblem(Protocol):
     def finish(self, state: Any, segment: Any) -> None:
         """Record the final ``lambda = 0`` vertex (the segment's intercept)."""
         ...  # pragma: no cover
+
+
+class InequalityConstrained:
+    """Mixin: normalise optional ``G x <= h`` inequality rows for a parametric problem.
+
+    Both the CLA (``G w <= h`` exposure caps) and the LASSO (``G beta <= h``) carry an
+    optional inequality system through the same bordered machinery, so normalising the
+    raw ``g``/``h`` inputs -- and counting the resulting path-length coordinates -- lives
+    here once rather than being duplicated in each class. A concrete problem supplies the
+    ``g``/``h`` inputs (``None`` when there are no inequality rows) and a ``dimension``.
+    """
+
+    g: NDArray[np.float64] | None
+    h: NDArray[np.float64] | None
+
+    @property
+    def dimension(self) -> int:
+        """Number of coordinates ``n``; provided by the concrete problem class."""
+        raise NotImplementedError  # pragma: no cover
+
+    @cached_property
+    def g_matrix(self) -> NDArray[np.float64]:
+        """Inequality matrix ``G`` of ``G x <= h`` as a ``(p, n)`` float array.
+
+        ``None`` is normalised to an empty ``(0, n)`` matrix, so the inequality
+        machinery is a no-op and the trace reduces exactly to the unconstrained
+        problem. This is the single point where the inequality input is normalised.
+        """
+        if self.g is None:
+            return np.zeros((0, self.dimension))
+        return np.atleast_2d(np.asarray(self.g, dtype=np.float64))
+
+    @cached_property
+    def h_vector(self) -> NDArray[np.float64]:
+        """Inequality right-hand side ``h`` of ``G x <= h`` as a ``(p,)`` float array (empty if none)."""
+        if self.h is None:
+            return np.zeros(0)
+        return np.atleast_1d(np.asarray(self.h, dtype=np.float64))
+
+    @property
+    def event_dimension(self) -> int:
+        """Coordinate count for the tracer's path-length safety cap: ``n`` + ``p`` rows.
+
+        Each turning point fixes the activity of exactly one coordinate -- a box bound
+        (or LASSO coefficient) or an inequality row of ``G x <= h`` -- so the iteration
+        cap scales with ``n + p`` rather than ``n`` alone. With no inequality rows this
+        is just ``n``.
+        """
+        return self.dimension + int(self.g_matrix.shape[0])
 
 
 def select_next_event(l_mat: NDArray[np.float64], lam: float, tol: float) -> tuple[int, int, float] | None:


### PR DESCRIPTION
Both `CLA` (`G w ≤ h` exposure caps) and `Lasso` (`G β ≤ h`) independently defined the same three members for their optional-inequality support:

- `event_dimension` — **byte-identical** (`dimension + g_matrix.shape[0]`)
- `g_matrix` / `h_vector` — identical except the CLA cast `g`/`h` to `float64` and the LASSO **did not**

This factors the three into an `InequalityConstrained` mixin in `pathtracer.py` (co-located with the `ParametricProblem` protocol both problem types already implement) and inherits it from both classes. Each class keeps its own problem-specific `dimension` (`len(mean)` vs `x.shape[1]`).

### Small correctness fix
The LASSO now normalizes `g`/`h` to `float64` through the shared helper, so an **integer-typed** constraint array behaves the same as it already did for the CLA (previously the LASSO skipped that cast).

### No behaviour change otherwise
Same paths everywhere. The mixin's abstract `dimension` stub is `# pragma: no cover` (always overridden by the concrete class).

### Net
`+54 / −54` lines — the removed duplication ≈ the size of the mixin, but now single-sourced (cla.py −33, lasso.py −21, pathtracer.py +50).

`make test`: **257 passed, 100% coverage**; `ruff` + `mypy --strict` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)