### PR TITLE
fix: relative event-selection tolerance removes large-frontier degradation

### DIFF
--- a/src/cvxcla/pathtracer.py
+++ b/src/cvxcla/pathtracer.py
@@ -136,29 +136,43 @@ def select_next_event(l_mat: NDArray[np.float64], lam: float, tol: float) -> tup
     The current segment is valid only for ``lambda`` at or below the current value
     (the path is traced with non-increasing ``lambda``), so ratios above it are
     spurious crossings outside the segment and are discarded; if none remain the
-    trace is complete. Among events tied (within ``tol``) for the largest valid
-    ratio, a Bland-style lowest-``(coordinate, event type)`` rule makes the choice
-    deterministic and prevents cycling on degenerate problems.
+    trace is complete. Among events tied for the largest valid ratio, a Bland-style
+    lowest-``(coordinate, event type)`` rule makes the choice deterministic and
+    prevents cycling on degenerate problems.
+
+    Two events are "the same" breakpoint only when their ``lambda`` values agree to
+    floating-point scale, so the validity window and the tie-break use a tolerance
+    *relative* to the ``lambda`` magnitude. A fixed absolute tolerance mis-ranks the
+    densely spaced breakpoints of large paths: their spacing shrinks with the problem
+    size, so an absolute window eventually merges genuinely distinct events, picks the
+    wrong one by the tie-break, and lets ``lambda`` step backwards. The caller's
+    ``tol`` is treated as an upper bound on this relative rate; event ordering needs a
+    roundoff-scale window regardless of the coarser ``tol`` used elsewhere (e.g. to
+    classify a weight as sitting on a bound). Finally, the chosen ``lambda`` is clamped
+    below the current value, so roundoff in the segment solve can never make a
+    breakpoint appear above it.
 
     Args:
         l_mat: The ``(n, k)`` matrix of candidate critical ``lambda`` values.
         lam: The current (upper) ``lambda`` bound on valid events.
-        tol: Tolerance for the validity window and the tie-break.
+        tol: Upper bound on the relative event-ordering tolerance.
 
     Returns:
         ``(sec, direction, lam_next)`` for the chosen event, or ``None`` if no
         valid event remains.
     """
     l_mat = l_mat.copy()  # do not mutate the caller's matrix
-    l_mat[l_mat > lam + tol] = -np.inf  # pragma: no mutate
+    rate = min(tol, 1e-10)  # roundoff-scale relative window; tol is only an upper bound
+    l_mat[l_mat > lam + rate * max(1.0, abs(lam))] = -np.inf  # pragma: no mutate
 
     lam_max = np.max(l_mat)
     if lam_max < 0:  # pragma: no mutate
         return None
 
-    tied = np.argwhere(l_mat >= lam_max - tol)  # pragma: no mutate
+    tied = np.argwhere(l_mat >= lam_max - rate * max(1.0, abs(lam_max)))  # pragma: no mutate
     sec, direction = tied[0]
-    return int(sec), int(direction), float(l_mat[sec, direction])
+    # lambda is non-increasing along the path: clamp away any roundoff overshoot.
+    return int(sec), int(direction), float(min(lam, l_mat[sec, direction]))
 
 
 def trace(problem: ParametricProblem) -> None:


### PR DESCRIPTION
## Problem

`pathtracer.select_next_event` used the coarse, **absolute** tolerance `tol` (default `1e-5`, shared with weight/bound classification in `first.py` and constraint validation in `cla.py`) for both the validity window and the Bland tie-break.

Breakpoint spacing shrinks as the problem grows (min absolute λ-gap ~3e-6 at N=100 → ~2e-8 at N=800; min **relative** gap 2e-4 → 6e-7 by N=1600). So on large frontiers the absolute window merged genuinely distinct events, the tie-break picked the wrong one, and **λ stepped backwards** — producing out-of-order turning points. The symptom was a long-only frontier with non-monotone returns (~1e-4 at N=800, growing with N). No error was raised: the frontier was just silently slightly wrong. Small problems (≤~150 assets) were unaffected.

## Fix (self-contained in `select_next_event`)

1. Make both windows **relative** to the λ magnitude, capped at a roundoff-scale rate `min(tol, 1e-10)`. `tol` is now only an *upper bound* on the ordering tolerance, decoupled from the coarser semantic `tol` used elsewhere.
2. **Clamp** the chosen λ to `min(current, candidate)` so roundoff in the segment solve can never make a breakpoint appear above the current value.

(Refusing λ-increases *strictly*, with zero slack, was too aggressive — it dropped ~90 genuine events at N=800. The small roundoff slack plus the clamp is what reproduces the correct path.)

## Verification

- Default-`tol` frontier now **reproduces the tight-tol reference exactly** (identical turning-point counts and coordinates, `max|Δ|=0`) at N = 100 / 800 / 3200 / 12800.
- **Monotone to N=12,800** (worst 4e-15 = roundoff), vs divergence beyond ~N=150 before.
- **Anti-cycling preserved** on tied/duplicated assets.
- **All 248 tests pass**; the direct `select_next_event` unit tests are unchanged.

## Scope / caveat

This removes the degradation on **general-position** data (the practical case). It does **not** dissolve the adversarial worst case where breakpoints crowd below floating-point resolution — that remains the open question discussed in the companion paper's §9.

## Note for sequencing

`pathtracer.py` is also touched by #766 (which adds `ParametricProblem` protocol methods above `select_next_event`). The regions don't overlap, but the two should be merged in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)