### PR TITLE
refactor: extract shared bordered KKT solve into operators.bordered_solve

### DIFF
--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .builder import ProblemBuilder
 
 from .first import first_vertex_lp, init_algo
-from .operators import DenseCovariance, QuadraticForm
+from .operators import DenseCovariance, QuadraticForm, bordered_solve
 from .pathtracer import InequalityConstrained, trace
 from .types import Frontier, FrontierPoint, TurningPoint
 
@@ -377,28 +377,26 @@ class CLA(InequalityConstrained):
         # of the reduced QP at this vertex.
         c = np.vstack([self.a, self.g_matrix[active_ineq]])
         d = np.concatenate([self.b, self.h_vector[active_ineq]])
-        mc = c.shape[0]
         c_free = c[:, free_in]
 
-        # [Sigma_FF  C_F.T] [x ]   [r1]   solved for the alpha (weights) and beta
-        # [C_F       0    ] [nu] = [r2]   systems via Sigma_FF^{-1} [C_F.T | r1_a | r1_b]
-        rhs_free = np.column_stack([c_free.T, -cov.cross(free_in, fixed_weights), self.mean[free_in]])
-        solved = cov.solve_free(free_in, rhs_free)
-        y = solved[:, :mc]  # Sigma_FF^{-1} C_F.T
-        z_alpha = solved[:, mc]
-        z_beta = solved[:, mc + 1]
+        # The reduced KKT system is the shared bordered solve: the constant system
+        # carries the blocked-weight shift -Sigma_FB w_B and the reduced constraint
+        # right-hand side d - C_B w_B; the slope system carries the mean with a zero
+        # constraint right-hand side (A r_beta = 0).
+        x_alpha, x_beta, nu_alpha, nu_beta = bordered_solve(
+            cov,
+            free_in,
+            c_free,
+            -cov.cross(free_in, fixed_weights),
+            self.mean[free_in],
+            d - c[:, out] @ fixed_weights[out],
+            np.zeros(c.shape[0]),
+        )
 
-        # Schur complement C_F Sigma_FF^{-1} C_F.T and the stacked multipliers
-        schur = c_free @ y
-        r2_alpha = d - c[:, out] @ fixed_weights[out]
-        nu = np.linalg.solve(schur, np.column_stack([c_free @ z_alpha - r2_alpha, c_free @ z_beta]))
-        nu_alpha, nu_beta = nu[:, 0], nu[:, 1]
-
-        # Back-substitute the free weights
         r_alpha = fixed_weights.copy()
-        r_alpha[free_in] = z_alpha - y @ nu_alpha
+        r_alpha[free_in] = x_alpha
         r_beta = np.zeros(ns)
-        r_beta[free_in] = z_beta - y @ nu_beta
+        r_beta[free_in] = x_beta
 
         gamma = cov.matvec(r_alpha) + c.T @ nu_alpha
         delta = cov.matvec(r_beta) + c.T @ nu_beta - self.mean

--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -51,7 +51,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import numpy as np
 from numpy.typing import NDArray
 
-from .operators import DenseCovariance, GramCovariance, QuadraticForm
+from .operators import DenseCovariance, GramCovariance, QuadraticForm, bordered_solve
 from .pathtracer import InequalityConstrained, trace
 
 if TYPE_CHECKING:
@@ -271,28 +271,22 @@ class Lasso(InequalityConstrained):
             # Empty support (e.g. the non-negative path when no correlation is
             # positive): beta = 0, correlation = X^T y, and there is nothing to solve.
             return _LassoSegment(alpha, beta_slope, xty.copy(), np.zeros(n), eta_alpha, eta_slope)
-        if not np.any(rows_active):
-            # Plain LASSO solve: beta_S(lam) = H_SS^{-1}(xty_S - lam s_S). Solve both
-            # right-hand sides at once so H_SS is factorised a single time per
-            # breakpoint (one np.linalg.solve, not two).
-            sol = self.quad.solve_free(active, np.column_stack([xty_s, signs_s]))
-            alpha[active] = sol[:, 0]
-            beta_slope[active] = sol[:, 1]
-        else:
-            # Bordered solve over (beta_S, eta_R): the active rows G_RS act as
-            # equality rows, exactly the CLA's Schur complement (cla.py).
-            g_rs = self.g_matrix[np.ix_(rows_active, active)]  # |R| x |S|
-            h_r = self.h_vector[rows_active]
-            rhs = np.column_stack([xty_s, signs_s, g_rs.T])  # |S| x (2 + |R|)
-            sol = self.quad.solve_free(active, rhs)
-            u0, u1, big_y = sol[:, 0], sol[:, 1], sol[:, 2:]  # big_y = H_SS^{-1} G_RS^T
-            schur = g_rs @ big_y  # |R| x |R|
-            eta_a = np.linalg.solve(schur, g_rs @ u0 - h_r)
-            eta_s = -np.linalg.solve(schur, g_rs @ u1)
-            alpha[active] = u0 - big_y @ eta_a
-            beta_slope[active] = u1 + big_y @ eta_s
-            eta_alpha[rows_active] = eta_a
-            eta_slope[rows_active] = eta_s
+
+        # The active rows G_RS act as equality rows in the reduced KKT system, exactly
+        # the CLA's bordered Schur solve (operators.bordered_solve). With no active rows
+        # (|R| = 0) this reduces to the plain LASSO solve beta_S(lam) = H_SS^{-1}(xty_S -
+        # lam s_S). The slope's constraint right-hand side is zero, and the slope
+        # multiplier nu carries the opposite sign convention to eta(lam) (beta = alpha -
+        # lam beta_slope here, vs w = r_alpha + lam r_beta in the CLA), hence the flip.
+        g_rs = self.g_matrix[np.ix_(rows_active, active)]  # |R| x |S|
+        h_r = self.h_vector[rows_active]
+        x_const, x_slope, eta_a, nu_slope = bordered_solve(
+            self.quad, active, g_rs, xty_s, signs_s, h_r, np.zeros(g_rs.shape[0])
+        )
+        alpha[active] = x_const
+        beta_slope[active] = x_slope
+        eta_alpha[rows_active] = eta_a
+        eta_slope[rows_active] = -nu_slope
 
         # Generalised correlation c(lam) = xty - H beta(lam) - G_R^T eta(lam) = p + lam q.
         g_r = self.g_matrix[rows_active]

--- a/src/cvxcla/operators.py
+++ b/src/cvxcla/operators.py
@@ -132,6 +132,56 @@ class QuadraticForm(Protocol):
         ...  # pragma: no cover
 
 
+def bordered_solve(
+    quad: QuadraticForm,
+    free: NDArray[np.bool_],
+    c_free: NDArray[np.float64],
+    rhs_const: NDArray[np.float64],
+    rhs_slope: NDArray[np.float64],
+    d_const: NDArray[np.float64],
+    d_slope: NDArray[np.float64],
+) -> tuple[
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+]:
+    """Solve the bordered KKT system ``[[H_FF, C_F^T], [C_F, 0]] @ [x; nu] = [rhs; d]``.
+
+    The shared segment solve of ``cvxcla.cla`` and ``cvxcla.lasso``. ``H_FF`` is the
+    free block of the quadratic form, ``C_F`` the constraint rows on the free columns.
+    The constant and ``lambda``-slope right-hand sides are solved together so ``H_FF``
+    is factorised once; ``mc == 0`` (no constraint rows) is the plain free-block solve.
+    ``H_FF`` is reached only through ``solve_free``, so structured backends never
+    materialise an ``n x n`` matrix. Returns ``(x_const, x_slope, nu_const, nu_slope)``:
+    the free solution and constraint multipliers per system (multipliers empty if
+    ``mc == 0``). Callers assemble the right-hand sides and interpret the outputs.
+    """
+    mc = c_free.shape[0]
+    if mc == 0:
+        sol = quad.solve_free(free, np.column_stack([rhs_const, rhs_slope]))
+        empty: NDArray[np.float64] = np.zeros(0)
+        return sol[:, 0], sol[:, 1], empty, empty
+
+    # One multi-RHS solve against H_FF covers the constraint columns C_F^T and both
+    # the constant and slope systems, so H_FF is factorised a single time.
+    solved = quad.solve_free(free, np.column_stack([c_free.T, rhs_const, rhs_slope]))
+    y = solved[:, :mc]  # H_FF^{-1} C_F^T
+    z_const = solved[:, mc]
+    z_slope = solved[:, mc + 1]
+
+    # Schur complement C_F H_FF^{-1} C_F^T and the stacked multipliers.
+    schur = c_free @ y
+    nu = cast(
+        "NDArray[np.float64]",
+        np.linalg.solve(schur, np.column_stack([c_free @ z_const - d_const, c_free @ z_slope - d_slope])),
+    )
+    nu_const, nu_slope = nu[:, 0], nu[:, 1]
+
+    # Back-substitute the free solution.
+    return z_const - y @ nu_const, z_slope - y @ nu_slope, nu_const, nu_slope
+
+
 @dataclass(frozen=True)
 class DenseCovariance:
     """Dense reference implementation of the ``CovarianceOperator`` protocol.


### PR DESCRIPTION
## Summary

`CLA._solve_kkt` and `Lasso.segment` ran the **same bordered Schur-complement KKT solve** at every segment. This gives that ~20-line kernel a single home, `operators.bordered_solve`, next to the `QuadraticForm` backend it consumes.

The kernel solves the saddle-point system

```
[[H_FF, C_Fᵀ], [C_F, 0]] @ [x; nu] = [rhs; d]
```

for a constant and a λ-slope right-hand side, sharing one factorisation of `H_FF`. An `mc == 0` fast path is the plain free-block solve.

## This is a single-source-of-truth change, not a line reduction

Honest accounting: net LOC goes **up** (`+84 / -42`). The kernel's body is ~20 lines; the call sites only shrink modestly because each keeps its problem-specific glue:

- **RHS assembly** — CLA's blocked-weight shift `−cov.cross` and reduced constraint RHS `d − C_B w_B`; Lasso's `xty`/`signs`.
- **Sign convention** — Lasso's `eta_slope = −nu_slope` for the `β = α − λ·β_slope` orientation (vs CLA's `w = r_alpha + λ·r_beta`).
- **Output decoding** — CLA's `gamma`/`delta` gradients vs Lasso's generalised correlation `p`/`q`; scattering active-row multipliers back to full length.

The concrete wins: the bordered solve now has **one tested implementation instead of two hand-synced copies**, and Lasso loses a branch (the `mc == 0` path collapses its plain and bordered solves into one call).

## Correctness

No behavioural change — the algebra is identical term-by-term (CLA's `r2_alpha = d − C_B w_B` reduces to Lasso's `h_r` since blocked coefficients are zero; the slope-multiplier sign is the only real difference, captured by the explicit flip).

- ✅ 231 functional tests pass (CLA/LASSO frontier & path, `test_solve_kkt_is_feasible_and_optimal_segment`, the LASSO subgradient `_kkt_violation` check)
- ✅ mypy clean
- ✅ ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)