### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for cvxcla

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for cvxcla.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs cvxcla and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies so PyInstaller can discover
+# and bundle cvxcla into each frozen fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover numpy's C-extension submodules on its own, so
+# the frozen fuzzer crashes at runtime with
+# "No module named 'numpy._core._exceptions'". --collect-all pulls in every
+# numpy submodule, data file and shared library.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all scipy
+done

--- a/tests/fuzz/fuzz_operators.py
+++ b/tests/fuzz/fuzz_operators.py
@@ -1,0 +1,60 @@
+"""Fuzz the cvxcla DenseCovariance quadratic-form operator.
+
+``DenseCovariance`` wraps a symmetric covariance matrix and exposes ``matvec``
+and ``solve_free`` (the free-block linear solve at the heart of the critical-line
+algorithm). Neither should crash with an unexpected exception on adversarial
+input — non-square/asymmetric matrices are rejected in ``__post_init__``, and
+singular free blocks should raise a documented error (or numpy's
+``LinAlgError``). This harness exercises that contract with coverage-guided
+input.
+
+Run locally:
+    pip install atheris numpy scipy
+    python tests/fuzz/fuzz_operators.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the native dependencies OUTSIDE the instrumentation block so they
+# load uninstrumented; only the first-party package under test is instrumented.
+import numpy as np
+import scipy.linalg  # noqa: F401  # pre-imported uninstrumented
+
+with atheris.instrument_imports():
+    from cvxcla.operators import DenseCovariance
+
+_ALLOWED = (ValueError, TypeError, np.linalg.LinAlgError)
+
+
+def test_one_input(data: bytes) -> None:
+    """Build a DenseCovariance and exercise matvec/solve_free with fuzzed data."""
+    fdp = atheris.FuzzedDataProvider(data)
+    n = fdp.ConsumeIntInRange(1, 6)
+    raw = np.array([fdp.ConsumeFloat() for _ in range(n * n)], dtype=np.float64).reshape(n, n)
+    # Symmetrise so construction passes its symmetry check and the numeric paths
+    # (matvec/solve_free) are actually exercised rather than only the guard.
+    matrix = (raw + raw.T) / 2.0
+
+    with contextlib.suppress(_ALLOWED):
+        cov = DenseCovariance(matrix=matrix)
+        cov.matvec(np.array([fdp.ConsumeFloat() for _ in range(n)], dtype=np.float64))
+        free = np.array([fdp.ConsumeBool() for _ in range(n)], dtype=np.bool_)
+        rhs = np.array([fdp.ConsumeFloat() for _ in range(int(free.sum()))], dtype=np.float64)
+        cov.solve_free(free, rhs)
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Opt-in **ClusterFuzzLite** scaffold so the existing `rhiza_fuzzing.yml` runs.
- `.clusterfuzzlite/Dockerfile` + `build.sh` (`--collect-all numpy/scipy`)
- `tests/fuzz/fuzz_operators.py` — fuzzes `DenseCovariance.matvec`/`solve_free` with arbitrary symmetric matrices

## Test plan
- [x] Built **and run** against the OSS-Fuzz `base-builder-python` image — 2500 runs, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
