### PR TITLE
Docs: fix stale operators.py reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,8 @@ Synced from the template — treat as read-only. Highlights from
 ### Locally owned (edit freely — this is the actual project)
 
 - `src/cvxcla/` — the library. Modules: `cla.py` (the CLA solver), `lasso.py`,
-  `operators.py` (matrix/Cholesky update operators), `builder.py`, `types.py`,
+  the `operators/` package (`_core.py`, `dense.py`, `factor.py`, `gram.py` —
+  the covariance/quadratic-form backends), `builder.py`, `types.py`,
   `pathtracer.py`, `first.py` (first turning point), `__init__.py`.
 - `tests/` — the project test suite (unit, property-based `test_properties.py`,
   fuzz `tests/fuzz/`, benchmarks `tests/benchmarks/`). **Note:**


### PR DESCRIPTION
Closes #797

CLAUDE.md line 50 listed `operators.py` as a library module, but that file no longer exists — it was split into the `operators/` package (`_core.py`, `dense.py`, `factor.py`, `gram.py`, `__init__.py`). This updates the contributor-facing module map to describe the package accurately.

Documentation-only change. Confirming gate: `make fmt` (markdownlint) green.