### PR TITLE
Docs: document nonneg and gram in the Lasso docstring

### DIFF
--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -132,6 +132,12 @@ class Lasso(InequalityConstrained):
         g: Optional inequality matrix ``(p, n)`` of ``G beta <= h``; ``None`` means
             the plain LASSO.
         h: Optional inequality right-hand side ``(p,)``; must be strictly positive.
+        nonneg: When ``True``, restrict to the non-negative LASSO ``beta >= 0``;
+            the default ``False`` traces the ordinary signed path.
+        gram: When ``True``, drive the path with the ``GramCovariance`` data-matrix
+            backend (Woodbury solves in the ``m``-dimensional observation space),
+            never materialising the ``n x n`` Gram ``X^T X`` — the win in the
+            ``n >> m`` regime. The default ``False`` forms the dense Gram.
         tol: Tolerance for event selection and the validity window.
         path: The discovered breakpoints, populated on construction.
         quad_form: Optional ``QuadraticForm`` operator ``H`` (operator mode).


### PR DESCRIPTION
Closes #798

The `Lasso` dataclass declares `nonneg: bool` and `gram: bool` fields, but the `Attributes:` section of the class docstring documented every other field except these two. This adds both, with `gram` described as the `GramCovariance` data-matrix backend (Woodbury in observation space) rather than forming the dense `X^T X` — matching the actual behaviour in `Lasso.quad`.

Confirming gate: `make test` green, coverage 100.00%.