### PR TITLE
Docs: clean up malformed leftover comment in first.py

### DIFF
--- a/src/cvxcla/first.py
+++ b/src/cvxcla/first.py
@@ -68,7 +68,7 @@ def init_algo(
             break
 
     if not np.any(free):
-        #    # We have not reached the target sum of weights...
+        # No asset ended up interior: the bounds cannot sum to the target.
         msg = "Could not construct a fully invested portfolio"
         raise ValueError(msg)
 


### PR DESCRIPTION
Closes #799

`first.py` line 71 had a malformed leftover comment (`#    # We have not reached...`) with a stray second `#` inside the "no interior asset" error branch of `init_algo`. Replaced it with a single, well-formed explanatory comment.

Confirming gate: `make test` green, coverage 100.00%.