### PR TITLE
Docs: update stale Rhiza pin in CLAUDE.md (v0.19.5 -> v0.19.9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The pin lives in `.rhiza/template.yml`:
 
 ```yaml
 repository: "jebel-quant/rhiza"
-ref: "v0.19.5"
+ref: "v0.19.9"
 profiles:
   - github-project
 ```


### PR DESCRIPTION
Closes #803

## What changed
`CLAUDE.md` documented the Rhiza pin in its illustrative `template.yml` snippet as `ref: "v0.19.5"`, but the real pin in `.rhiza/template.yml` is `v0.19.9` (bumped in #796). Updated the one `ref:` line in the snippet so the doc matches reality.

## Scope
- Single locally-owned Markdown file (`CLAUDE.md` is not in `.rhiza/template.lock`).
- No `src/`/`tests/` changes.

## Confirming gate
`make fmt` passes (markdownlint clean).