### PR TITLE
Refactor: delegate operator backends to cvx-linalg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ classifiers = [
 dependencies = [
     "numpy>=2.0.0",
     "scipy>=1.11",
+    # TODO(pre-merge): pin ">=<released cvx-linalg with operators+ridge>" and drop
+    # the [tool.uv.sources] override below once cvx-linalg is released.
+    "cvx-linalg",
 ]
 
 authors = [{name = "Thomas Schmelzer", email = "thomas.schmelzer@gmail.com"},
@@ -48,6 +51,11 @@ lint = []
 # make a fresh `uv run pytest` work without knowing about dependency groups
 [tool.uv]
 default-groups = ["dev", "test"]
+
+# Temporary: track the operator/ridge work in cvx-linalg before it is released.
+# Remove once a release containing SymmetricOperator + GramOperator ridge is on PyPI.
+[tool.uv.sources]
+cvx-linalg = { git = "https://github.com/Jebel-Quant/linalg.git", branch = "gram-ridge" }
 
 [build-system]
 requires = ["hatchling"]

--- a/src/cvxcla/operators/dense.py
+++ b/src/cvxcla/operators/dense.py
@@ -10,11 +10,13 @@ updates, trading numerical robustness for speed on dense problems.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 from typing import cast
 
 import numpy as np
+from cvx.linalg import DenseOperator
 from numpy.typing import NDArray
-from scipy.linalg import cho_factor, cho_solve  # type: ignore[import-untyped]
+from scipy.linalg import cho_factor  # type: ignore[import-untyped]
 from scipy.linalg.lapack import get_lapack_funcs  # type: ignore[import-untyped]
 
 from ._core import _RCOND_ESTIMATE_MARGIN, _rcond_symmetric
@@ -56,6 +58,11 @@ class DenseCovariance:
             msg = "Covariance must be symmetric"
             raise ValueError(msg)
 
+    @cached_property
+    def _operator(self) -> DenseOperator:
+        """The shared ``cvx.linalg`` operator backing the products (never re-formed)."""
+        return DenseOperator(self.matrix)
+
     @property
     def n(self) -> int:
         """Number of assets (the dimension of the covariance)."""
@@ -70,10 +77,13 @@ class DenseCovariance:
         Returns:
             ``Sigma @ x`` with the same trailing shape as ``x``.
         """
-        return self.matrix @ x
+        return cast("NDArray[np.float64]", self._operator.matvec(x))
 
     def solve_free(self, free: NDArray[np.bool_], rhs: NDArray[np.float64]) -> NDArray[np.float64]:
         """Solve the free-block system ``Sigma[free][:, free] @ y = rhs``.
+
+        Delegates to the shared ``DenseOperator`` (Cholesky with an LU fallback);
+        the CLA's ``rcond_free`` guard keeps rank-deficient blocks away from here.
 
         Args:
             free: Boolean mask of shape ``(n,)`` selecting the free assets.
@@ -82,15 +92,7 @@ class DenseCovariance:
         Returns:
             The solution ``y`` with the same shape as ``rhs``.
         """
-        block = self.matrix[np.ix_(free, free)]
-        try:
-            # The free block of a covariance/Gram matrix is symmetric positive
-            # definite, so Cholesky is ~1.5x faster than a general LU solve.
-            return cast("NDArray[np.float64]", cho_solve(cho_factor(block, overwrite_a=True, check_finite=False), rhs))
-        except np.linalg.LinAlgError:
-            # Not numerically positive definite (rank-deficient / indefinite):
-            # fall back to the general solve, which the degeneracy guards handle.
-            return cast("NDArray[np.float64]", np.linalg.solve(self.matrix[np.ix_(free, free)], rhs))
+        return cast("NDArray[np.float64]", self._operator.solve_free(np.flatnonzero(free), rhs))
 
     def cross(self, free: NDArray[np.bool_], x: NDArray[np.float64]) -> NDArray[np.float64]:
         """Compute the free-to-blocked cross product ``Sigma[free][:, ~free] @ x[~free]``.
@@ -104,7 +106,10 @@ class DenseCovariance:
             Vector of shape ``(n_free,)``.
         """
         blocked = ~free
-        return self.matrix[np.ix_(free, blocked)] @ x[blocked]
+        return cast(
+            "NDArray[np.float64]",
+            self._operator.block_matvec(np.flatnonzero(free), np.flatnonzero(blocked), x[blocked]),
+        )
 
     def rcond_free(self, free: NDArray[np.bool_]) -> float:
         """Reciprocal condition number of the free block; see the protocol."""

--- a/src/cvxcla/operators/factor.py
+++ b/src/cvxcla/operators/factor.py
@@ -13,6 +13,7 @@ from functools import cached_property
 from typing import cast
 
 import numpy as np
+from cvx.linalg import FactorOperator
 from numpy.typing import NDArray
 
 
@@ -103,11 +104,9 @@ class FactorCovariance:
         return self.delta
 
     @cached_property
-    def _delta_inv(self) -> NDArray[np.float64]:
-        """The inverse of the ``(k, k)`` factor covariance."""
-        if self.delta.ndim == 1:
-            return np.diag(1.0 / self.delta)
-        return cast("NDArray[np.float64]", np.linalg.inv(self.delta))
+    def _operator(self) -> FactorOperator:
+        """Shared ``cvx.linalg`` operator for ``Sigma = diag(d) + U Delta U.T`` (Woodbury solves)."""
+        return FactorOperator(self.d, self.u, self._delta_matrix)
 
     def matvec(self, x: NDArray[np.float64]) -> NDArray[np.float64]:
         """Compute the matrix-vector product ``Sigma @ x``.
@@ -119,16 +118,15 @@ class FactorCovariance:
             ``Sigma @ x`` with the same trailing shape as ``x``, computed in
             ``O(n k)`` per column.
         """
-        low_rank = self.u @ (self._delta_matrix @ (self.u.T @ x))
-        diagonal = self.d * x if x.ndim == 1 else self.d[:, None] * x
-        return diagonal + low_rank
+        return cast("NDArray[np.float64]", self._operator.matvec(x))
 
     def solve_free(self, free: NDArray[np.bool_], rhs: NDArray[np.float64]) -> NDArray[np.float64]:
         """Solve the free-block system ``Sigma[free][:, free] @ y = rhs`` via Woodbury.
 
-        Forms the ``k x k`` correction matrix
-        ``W = Delta^{-1} + U_F^T D_F^{-1} U_F`` and solves against it, so the
-        cost is ``O(n_F k^2 + k^3 + n_F k r)`` for ``r`` right-hand sides.
+        Delegates to the shared ``FactorOperator``, which forms the ``k x k``
+        correction matrix ``W = Delta^{-1} + U_F^T D_F^{-1} U_F`` and solves
+        against it, so the cost is ``O(n_F k^2 + k^3 + n_F k r)`` for ``r``
+        right-hand sides.
 
         Args:
             free: Boolean mask of shape ``(n,)`` selecting the free assets.
@@ -137,16 +135,7 @@ class FactorCovariance:
         Returns:
             The solution ``y`` with the same shape as ``rhs``.
         """
-        d_free = self.d[free]
-        u_free = self.u[free]
-
-        rhs_2d = rhs if rhs.ndim == 2 else rhs[:, None]
-        dinv_rhs = rhs_2d / d_free[:, None]
-        dinv_u = u_free / d_free[:, None]
-
-        w = self._delta_inv + u_free.T @ dinv_u
-        solution = dinv_rhs - dinv_u @ np.linalg.solve(w, u_free.T @ dinv_rhs)
-        return solution if rhs.ndim == 2 else solution[:, 0]
+        return cast("NDArray[np.float64]", self._operator.solve_free(np.flatnonzero(free), rhs))
 
     def cross(self, free: NDArray[np.bool_], x: NDArray[np.float64]) -> NDArray[np.float64]:
         """Compute the free-to-blocked cross product ``Sigma[free][:, ~free] @ x[~free]``.
@@ -164,7 +153,10 @@ class FactorCovariance:
             Vector of shape ``(n_free,)``.
         """
         blocked = ~free
-        return self.u[free] @ (self._delta_matrix @ (self.u[blocked].T @ x[blocked]))
+        return cast(
+            "NDArray[np.float64]",
+            self._operator.block_matvec(np.flatnonzero(free), np.flatnonzero(blocked), x[blocked]),
+        )
 
     def rcond_free(self, free: NDArray[np.bool_]) -> float:
         """Lower bound on the free block's reciprocal condition number.

--- a/src/cvxcla/operators/gram.py
+++ b/src/cvxcla/operators/gram.py
@@ -14,6 +14,7 @@ from functools import cached_property
 from typing import cast
 
 import numpy as np
+from cvx.linalg import GramOperator
 from numpy.typing import NDArray
 
 
@@ -102,6 +103,17 @@ class GramCovariance:
         """The sample-covariance scale ``1 / (T - 1)`` (``ddof = 1``, matching ``np.cov``)."""
         return 1.0 / (self._t - 1)
 
+    @cached_property
+    def _operator(self) -> GramOperator:
+        """Shared ``cvx.linalg`` operator for ``Sigma = W.T W + ridge I``, ``W = sqrt(scale) X_c``.
+
+        Absorbing the sample-covariance scale into the factor makes this exactly
+        the centered, ``1/(T-1)``-scaled sample covariance with the optional
+        ridge; the ``n x n`` matrix is still never formed.
+        """
+        w = np.sqrt(self._scale) * self._centered
+        return GramOperator(w, ridge=self.ridge)
+
     @property
     def n(self) -> int:
         """Number of assets (the dimension of the covariance)."""
@@ -117,9 +129,7 @@ class GramCovariance:
             ``Sigma @ x`` with the same trailing shape as ``x``, in ``O(T n)`` per
             column and without forming the ``n x n`` covariance.
         """
-        xc = self._centered
-        product = self._scale * (xc.T @ (xc @ x))
-        return product + self.ridge * x
+        return cast("NDArray[np.float64]", self._operator.matvec(x))
 
     def cross(self, free: NDArray[np.bool_], x: NDArray[np.float64]) -> NDArray[np.float64]:
         """Compute the free-to-blocked cross product ``Sigma[free][:, ~free] @ x[~free]``.
@@ -136,9 +146,10 @@ class GramCovariance:
             Vector of shape ``(n_free,)``.
         """
         blocked = ~free
-        xc_free = self._centered[:, free]
-        xc_blocked = self._centered[:, blocked]
-        return self._scale * (xc_free.T @ (xc_blocked @ x[blocked]))
+        return cast(
+            "NDArray[np.float64]",
+            self._operator.block_matvec(np.flatnonzero(free), np.flatnonzero(blocked), x[blocked]),
+        )
 
     def solve_free(self, free: NDArray[np.bool_], rhs: NDArray[np.float64]) -> NDArray[np.float64]:
         """Solve ``Sigma[free][:, free] @ y = rhs`` from the free columns of ``X_c``.
@@ -149,7 +160,7 @@ class GramCovariance:
         refuse). With a positive ridge the block is positive definite and, when
         there are more free assets than observations, the solve is done by the
         Woodbury identity in ``T``-space instead of inverting an ``n_F x n_F``
-        matrix.
+        matrix. Both paths live in the shared ``GramOperator``.
 
         Args:
             free: Boolean mask of shape ``(n,)`` selecting the free assets.
@@ -158,22 +169,7 @@ class GramCovariance:
         Returns:
             The solution ``y`` with the same shape as ``rhs``.
         """
-        xc_free = self._centered[:, free]
-        n_free = xc_free.shape[1]
-
-        if self.ridge > 0.0 and self._t < n_free:
-            # Woodbury in the T-dimensional observation space:
-            # (ridge I + W^T W)^{-1} = (1/ridge) I - (1/ridge^2) W^T (I + W W^T / ridge)^{-1} W,
-            # with W = sqrt(scale) X_cF (shape (T, n_free)).
-            w = np.sqrt(self._scale) * xc_free
-            correction_system = np.eye(self._t) + (w @ w.T) / self.ridge
-            correction = w.T @ np.linalg.solve(correction_system, w @ rhs)
-            return cast("NDArray[np.float64]", (rhs - correction / self.ridge) / self.ridge)
-
-        block = self._scale * (xc_free.T @ xc_free)
-        if self.ridge > 0.0:
-            block = block + self.ridge * np.eye(n_free)
-        return cast("NDArray[np.float64]", np.linalg.solve(block, rhs))
+        return cast("NDArray[np.float64]", self._operator.solve_free(np.flatnonzero(free), rhs))
 
     def rcond_free(self, free: NDArray[np.bool_]) -> float:
         """Reciprocal condition number of the free block, from the SVD of ``X_cF``.

--- a/uv.lock
+++ b/uv.lock
@@ -129,10 +129,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cvx-linalg"
+version = "0.8.0"
+source = { git = "https://github.com/Jebel-Quant/linalg.git?branch=gram-ridge#819c0ce238e07fc529520a967d5cc5740309bccc" }
+dependencies = [
+    { name = "numpy" },
+]
+
+[[package]]
 name = "cvxcla"
 version = "1.8.2"
 source = { editable = "." }
 dependencies = [
+    { name = "cvx-linalg" },
     { name = "numpy" },
     { name = "scipy" },
 ]
@@ -158,6 +167,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cvx-linalg", git = "https://github.com/Jebel-Quant/linalg.git?branch=gram-ridge" },
     { name = "kaleido", marker = "extra == 'plot'", specifier = "==1.3.0" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "plotly", marker = "extra == 'plot'", specifier = ">=6.0.1" },


### PR DESCRIPTION
## Summary
Delegate the linear-algebra in the covariance operator backends to the shared
`cvx.linalg` operators instead of reimplementing it in-module:

- `DenseCovariance` → `DenseOperator` (Cholesky with LU fallback)
- `FactorCovariance` → `FactorOperator` (Woodbury solves in factor space)
- `GramCovariance` → `GramOperator` (`Sigma = WᵀW + ridge·I`, Woodbury in T-space)

Each backend now holds a `cached_property _operator` and forwards `matvec`,
`cross`/`block_matvec`, and `solve_free` to it. The `n × n` covariance is still
never materialized, and the CLA's `rcond_free` guard continues to keep
rank-deficient blocks away from the solves.

## Dependency note (⚠️ pre-merge)
Adds a **temporary git dependency** on `cvx-linalg` (branch `gram-ridge`) via
`[tool.uv.sources]`. Before merge: pin `cvx-linalg>=<released version with
operators + ridge>` in `dependencies` and drop the `[tool.uv.sources]` override.
See the `TODO(pre-merge)` in `pyproject.toml`.

## Verification
- `make test`: **246 passed**, coverage **100.0%** on `src/` (gate = 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
