### PR TITLE
Address quality findings #808–#811

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The pin lives in `.rhiza/template.yml`:
 
 ```yaml
 repository: "jebel-quant/rhiza"
-ref: "v0.19.9"
+ref: "v1.0.1"
 profiles:
   - github-project
 ```
@@ -47,9 +47,11 @@ Synced from the template — treat as read-only. Highlights from
 ### Locally owned (edit freely — this is the actual project)
 
 - `src/cvxcla/` — the library. Modules: `cla.py` (the CLA solver), `lasso.py`,
-  the `operators/` package (`_core.py`, `dense.py`, `factor.py`, `gram.py` —
-  the covariance/quadratic-form backends), `builder.py`, `types.py`,
-  `pathtracer.py`, `first.py` (first turning point), `__init__.py`.
+  the `operators/` package (`_core.py` — the `QuadraticForm`/`CovarianceOperator`
+  protocols plus the `cross`/`bordered_solve` helpers; `builders.py` — factory
+  functions that wrap the `cvx.linalg` operators, `DenseOperator`/`GramOperator`/
+  `FactorOperator`, as covariance/quadratic-form backends), `builder.py`,
+  `types.py`, `pathtracer.py`, `first.py` (first turning point), `__init__.py`.
 - `tests/` — the project test suite (unit, property-based `test_properties.py`,
   fuzz `tests/fuzz/`, benchmarks `tests/benchmarks/`). **Note:**
   `.rhiza/tests/` is Rhiza-owned and tests the template itself, not this library.

--- a/src/cvxcla/cla.py
+++ b/src/cvxcla/cla.py
@@ -132,6 +132,10 @@ class CLA(InequalityConstrained):
         Returns:
             A ``ProblemBuilder`` ready to accept constraints.
         """
+        # Deferred (function-local) import on purpose: ``builder`` imports ``CLA`` at
+        # module level, so importing it at the top here would form a real import cycle.
+        # This factory only needs ``ProblemBuilder`` at call time, so the import is safe
+        # to defer. See also the ``TYPE_CHECKING`` import above and ``Lasso.problem``.
         from .builder import ProblemBuilder
 
         return ProblemBuilder(mean, covariance)

--- a/src/cvxcla/lasso.py
+++ b/src/cvxcla/lasso.py
@@ -163,39 +163,67 @@ class Lasso(InequalityConstrained):
                 constraint shapes are inconsistent, or any ``h`` entry is not
                 strictly positive (which would make ``beta = 0`` infeasible).
         """
-        operator_mode = self.quad_form is not None or self.linear is not None
-        if operator_mode:
-            if self.quad_form is None or self.linear is None:
-                msg = "quad_form and linear (X^T y) must be provided together"
-                raise ValueError(msg)
-            if self.x is not None or self.y is not None:
-                msg = "supply either a design (x, y) or an operator (quad_form, linear), not both"
-                raise ValueError(msg)
-            self.linear = np.asarray(self.linear, dtype=np.float64)
-            if self.linear.ndim != 1:
-                msg = f"linear must be the 1d vector X^T y, got shape {self.linear.shape}"
-                raise ValueError(msg)
+        if self.quad_form is not None or self.linear is not None:
+            self._validate_operator_inputs()
         else:
-            if self.x is None or self.y is None:
-                msg = "provide a design (x, y) or an operator (quad_form, linear)"
-                raise ValueError(msg)
-            if self.x.ndim != 2:
-                msg = f"x must be a 2d design matrix, got shape {self.x.shape}"
-                raise ValueError(msg)
-            if self.y.shape != (self.x.shape[0],):
-                msg = f"y must have shape ({self.x.shape[0]},), got {self.y.shape}"
-                raise ValueError(msg)
-        if self.g is not None or self.h is not None:
-            if self.g is None or self.h is None:
-                msg = "g and h must be provided together"
-                raise ValueError(msg)
-            if self.g.shape != (self.h.shape[0], self.dimension):
-                msg = f"g must have shape ({self.h.shape[0]}, {self.dimension}), got {self.g.shape}"
-                raise ValueError(msg)
-            if np.any(self.h <= self.tol):
-                msg = "h must be strictly positive so beta = 0 is feasible (equality/zero-h needs a feasibility seed)"
-                raise ValueError(msg)
+            self._validate_design_inputs()
+        self._validate_constraints()
         trace(self)
+
+    def _validate_operator_inputs(self) -> None:
+        """Validate the operator-mode inputs ``quad_form`` and ``linear`` (``X^T y``).
+
+        Raises:
+            ValueError: If only one of ``quad_form``/``linear`` is given, a design
+                ``(x, y)`` is also supplied, or ``linear`` is not the 1d ``X^T y``.
+        """
+        if self.quad_form is None or self.linear is None:
+            msg = "quad_form and linear (X^T y) must be provided together"
+            raise ValueError(msg)
+        if self.x is not None or self.y is not None:
+            msg = "supply either a design (x, y) or an operator (quad_form, linear), not both"
+            raise ValueError(msg)
+        self.linear = np.asarray(self.linear, dtype=np.float64)
+        if self.linear.ndim != 1:
+            msg = f"linear must be the 1d vector X^T y, got shape {self.linear.shape}"
+            raise ValueError(msg)
+
+    def _validate_design_inputs(self) -> None:
+        """Validate the dense-design inputs ``x`` and ``y``.
+
+        Raises:
+            ValueError: If ``x``/``y`` are missing, ``x`` is not a 2d design matrix,
+                or ``y``'s length does not match ``x``'s row count.
+        """
+        if self.x is None or self.y is None:
+            msg = "provide a design (x, y) or an operator (quad_form, linear)"
+            raise ValueError(msg)
+        if self.x.ndim != 2:
+            msg = f"x must be a 2d design matrix, got shape {self.x.shape}"
+            raise ValueError(msg)
+        if self.y.shape != (self.x.shape[0],):
+            msg = f"y must have shape ({self.x.shape[0]},), got {self.y.shape}"
+            raise ValueError(msg)
+
+    def _validate_constraints(self) -> None:
+        """Validate the optional inequality constraints ``G beta <= h``.
+
+        Raises:
+            ValueError: If only one of ``g``/``h`` is given, their shapes are
+                inconsistent with the problem dimension, or any ``h`` entry is not
+                strictly positive (which would make ``beta = 0`` infeasible).
+        """
+        if self.g is None and self.h is None:
+            return
+        if self.g is None or self.h is None:
+            msg = "g and h must be provided together"
+            raise ValueError(msg)
+        if self.g.shape != (self.h.shape[0], self.dimension):
+            msg = f"g must have shape ({self.h.shape[0]}, {self.dimension}), got {self.g.shape}"
+            raise ValueError(msg)
+        if np.any(self.h <= self.tol):
+            msg = "h must be strictly positive so beta = 0 is feasible (equality/zero-h needs a feasibility seed)"
+            raise ValueError(msg)
 
     @classmethod
     def problem(cls, x: NDArray[np.float64], y: NDArray[np.float64]) -> LassoBuilder:
@@ -212,6 +240,10 @@ class Lasso(InequalityConstrained):
         Returns:
             A :class:`cvxcla.builder.LassoBuilder`.
         """
+        # Deferred (function-local) import on purpose: ``builder`` imports ``Lasso`` at
+        # module level, so importing it at the top here would form a real import cycle.
+        # This factory only needs ``LassoBuilder`` at call time, so the import is safe to
+        # defer. See also the ``TYPE_CHECKING`` import above and ``CLA.problem``.
         from .builder import LassoBuilder
 
         return LassoBuilder(x, y)

--- a/tests/test_deferred_imports.py
+++ b/tests/test_deferred_imports.py
@@ -1,0 +1,66 @@
+"""Guard the deferred ``builder`` <-> solver import invariant.
+
+``builder`` imports ``CLA`` and ``Lasso`` at module level, so the solver modules
+must *not* import ``builder`` at module level in return -- that would form a real
+import cycle. Both ``CLA.problem`` and ``Lasso.problem`` therefore import
+``.builder`` function-locally. These tests pin both halves of the contract:
+
+* the solver modules keep the back-edge deferred (a hoisted top-level import
+  would be caught here rather than as a runtime ``ImportError``); and
+* the factories still build the right object at call time.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cvxcla import CLA, DenseCovariance, Lasso, LassoBuilder, ProblemBuilder
+
+
+def _module_level_imports(module_name: str) -> set[str]:
+    """Names imported at module level (top of file, not inside a function)."""
+    source = Path(importlib.import_module(module_name).__file__).read_text()
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in tree.body:  # only module-level statements, so function-local imports are excluded
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.add("." * node.level + (node.module or ""))
+    return names
+
+
+@pytest.mark.parametrize("module_name", ["cvxcla.cla", "cvxcla.lasso"])
+def test_solver_does_not_import_builder_at_module_level(module_name: str) -> None:
+    """Neither solver module may import ``builder`` at module level (would cycle)."""
+    assert ".builder" not in _module_level_imports(module_name)
+
+
+def test_cla_problem_builds_without_import_error() -> None:
+    """``CLA.problem`` resolves its deferred import and returns a ``ProblemBuilder``."""
+    mean = np.array([0.1, 0.2, 0.3])
+    covariance = np.eye(3)
+    assert isinstance(CLA.problem(mean, covariance), ProblemBuilder)
+
+
+def test_lasso_problem_builds_without_import_error() -> None:
+    """``Lasso.problem`` resolves its deferred import and returns a ``LassoBuilder``."""
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((10, 4))
+    y = rng.standard_normal(10)
+    assert isinstance(Lasso.problem(x, y), LassoBuilder)
+
+
+def test_lasso_from_operator_builds_without_import_error() -> None:
+    """``Lasso.from_operator`` constructs a traced ``Lasso`` in operator mode."""
+    rng = np.random.default_rng(1)
+    x = rng.standard_normal((10, 4))
+    y = rng.standard_normal(10)
+    lasso = Lasso.from_operator(DenseCovariance(x.T @ x), x.T @ y)
+    assert isinstance(lasso, Lasso)
+    assert lasso.path


### PR DESCRIPTION
Closes #808, closes #809, closes #810, closes #811 — the below-10 subcategories from the latest `rhiza_quality` scorecard.

## Changes

- **#808 — User-facing docs (7→10).** `CLAUDE.md`: refresh the `src/cvxcla/` module map to the current `operators/` layout (`_core.py` protocols/helpers + `builders.py` cvx-linalg factories, per #807), and correct the quoted Rhiza pin `v0.19.9` → `v1.0.1` to match `.rhiza/template.yml`.
- **#809 — Code complexity (8→10).** Split `Lasso.__post_init__` (cyclomatic complexity **C/18**) into `_validate_operator_inputs`, `_validate_design_inputs`, and `_validate_constraints`. No block in `src/` now ranks worse than **B** under `radon cc -s`.
- **#810 — Architecture (8→10).** Document the intentional deferred `builder`↔solver import back-edge with a rationale comment at `CLA.problem` (`cla.py`) and `Lasso.problem` (`lasso.py`).
- **#811 — Test design (9→10).** Add `tests/test_deferred_imports.py` pinning both halves of the invariant: the solver modules keep **no** module-level `builder` import (AST check), and `CLA.problem` / `Lasso.problem` / `Lasso.from_operator` still build at call time.

## Verification

- `make test` — 199 passed, coverage **100.0%** (up from 194 tests).
- `make fmt`, `make typecheck` — green.
- `radon cc src/cvxcla/lasso.py -n C` — no C-or-worse blocks remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)