### PR TITLE
chore: update rhiza to v1.2.5

### DIFF
--- a/.github/CONFIG.md
+++ b/.github/CONFIG.md
@@ -3,18 +3,15 @@
 This document describes the secrets used by the Rhiza-provided GitHub Actions workflows
 (`.github/workflows/rhiza_*.yml`) and how to configure them.
 
-## PAT_TOKEN (template sync)
+## PAT_TOKEN
 
-The sync workflow (`.github/workflows/rhiza_sync.yml`) keeps your repository up to date with the
-upstream Rhiza template. It commits the synced files directly to a branch or opens a pull request.
+Some workflows may need to push changes to files under `.github/workflows/`. The
+automatic `github.token` **cannot** do that — GitHub rejects such pushes unless
+the token carries the `workflow` scope. If you need it, create a Personal Access
+Token (PAT) with the `workflow` scope and store it as a repository secret named
+`PAT_TOKEN`.
 
-By default the workflow authenticates with the automatic `github.token`. That token **cannot push
-changes to files under `.github/workflows/`** — GitHub rejects such pushes unless the token has the
-`workflow` scope. Since template syncs regularly update workflow files, you should configure a
-Personal Access Token (PAT) with that scope and store it as a repository secret named `PAT_TOKEN`.
-
-If `PAT_TOKEN` is not configured, the workflow falls back to `github.token` and prints a warning.
-Syncs that touch only non-workflow files will still succeed.
+If `PAT_TOKEN` is not configured, workflows fall back to `github.token`.
 
 ### Creating the token
 

--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -27,12 +27,12 @@
       "parameters": {
         "strict_required_status_checks_policy": false,
         "required_status_checks": [
-          { "context": "Pre-commit hooks" },
-          { "context": "validation" },
-          { "context": "Check dependencies with deptry" },
-          { "context": "docs-coverage" },
-          { "context": "Security scanning" },
-          { "context": "License compliance scan" }
+          { "context": "Pre-commit hooks", "integration_id": 15368 },
+          { "context": "Check dependencies with deptry", "integration_id": 15368 },
+          { "context": "docs-coverage", "integration_id": 15368 },
+          { "context": "Security scanning", "integration_id": 15368 },
+          { "context": "License compliance scan", "integration_id": 15368 },
+          { "context": "CI gate", "integration_id": 15368 }
         ]
       }
     }

--- a/.github/rulesets/tag-protection.json
+++ b/.github/rulesets/tag-protection.json
@@ -1,0 +1,24 @@
+{
+  "name": "version-tag-protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "creation" },
+    { "type": "update" },
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.2.5
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.2.5
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.2.5
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.2.5
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.2.5
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.2.5
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.2.5
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -26,9 +26,10 @@
 #   7. 🐳 Publish Devcontainer - Build and publish devcontainer image (conditional)
 #   8. ✅ Finalize Release - Publish the GitHub release with links
 #
-# 📄 CHANGELOG: not updated here. The rhiza-tools `bump` command folds a freshly
-# generated CHANGELOG.md into the version-bump commit (git-cliff pre-commit hook),
-# so the tagged commit already carries the changelog — no separate post-tag commit.
+# 📄 CHANGELOG: not updated here. The release process (rhiza-claude `/release`)
+# folds a freshly generated CHANGELOG.md into the version-bump commit before the
+# tag is pushed, so the tagged commit already carries the changelog — no separate
+# post-tag commit.
 #
 # 📦 SBOM Generation:
 #   - Generated using CycloneDX format (industry standard for software supply chain security)
@@ -221,7 +222,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.2.2
+        uses: jebel-quant/actions/configure-git-auth@6d52725ca371d609489c5b50236965ad70bbe528 # v1
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.2.5
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.2.5
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.20'
+    rev: 'v0.16.0'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -71,12 +71,12 @@ repos:
         args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
 
   - repo: https://github.com/betterleaks/betterleaks
-    rev: v1.6.1
+    rev: v1.7.2
     hooks:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.26
+    rev: 0.12.0
     hooks:
       - id: uv-lock
 

--- a/.rhiza/.cfg.toml
+++ b/.rhiza/.cfg.toml
@@ -28,10 +28,22 @@ values = [
     "prod"
 ]
 
+# Anchored to the [project] table on purpose. `search`/`replace` are applied to
+# EVERY occurrence in the file, so the obvious `version = "{current_version}"`
+# also rewrites any [tool.*] table that happens to share the current number.
+# Dependency pins (httpx>=1.2.0, rich==1.2.0) are never at risk either way —
+# they are not line-anchored `version = ` assignments — but a second table is.
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = 'version = "{current_version}"'
-replace = 'version = "{new_version}"'
+regex = true
+search = '(?ms)^\[project\]((?:(?!^\[)[\s\S])*?)^version = "{current_version}"'
+replace = '[project]\1version = "{new_version}"'
+
+# NOTE for downstream projects: do NOT add a glob over your own
+# .github/workflows/*.yml here. Those stubs pin jebel-quant/rhiza's version
+# (the template you sync from), not your project's, so rewriting them with your
+# version would point them at a rhiza tag that does not exist. The template ref
+# is managed by /rhiza:update via .rhiza/template.yml instead.
 
 # Keep the reusable-workflow stubs in the bundles pinned to the current release.
 # These stubs are synced into downstream repos and must reference an existing tag.

--- a/.rhiza/completions/README.md
+++ b/.rhiza/completions/README.md
@@ -6,7 +6,7 @@ This directory contains shell completion scripts for Bash and Zsh that provide t
 
 - ✅ Tab-complete all available make targets
 - ✅ Show target descriptions in Zsh
-- ✅ Complete common make variables (DRY_RUN, BUMP, ENV, etc.)
+- ✅ Complete common make variables (DRY_RUN, ENV, etc.)
 - ✅ Works with any Rhiza-based project
 - ✅ Auto-discovers targets from Makefile and included .mk files
 
@@ -117,7 +117,7 @@ make <TAB>
 make te<TAB>  # Expands to: make test
 
 # Complete variables
-make BUMP=<TAB>  # Shows: patch, minor, major
+make ENV=<TAB>  # Shows: dev, staging, prod
 
 # Works with any target
 make doc<TAB>  # Shows: docs, docker-build, docker-run, etc.
@@ -144,7 +144,6 @@ The completion scripts understand these common variables:
 | Variable | Values | Description |
 |----------|--------|-------------|
 | `DRY_RUN` | `1` | Preview mode without making changes |
-| `BUMP` | `patch`, `minor`, `major` | Version bump type |
 | `ENV` | `dev`, `staging`, `prod` | Target environment |
 | `COVERAGE_FAIL_UNDER` | (number) | Minimum coverage threshold |
 | `PYTHON_VERSION` | (version) | Override Python version |
@@ -156,10 +155,10 @@ Example usage:
 make DRY_<TAB>     # Expands to: make DRY_RUN=1
 
 # Tab-complete variable values
-make BUMP=<TAB>    # Shows: patch minor major
+make ENV=<TAB>    # Shows: dev staging prod
 
 # Combine with targets
-make bump BUMP=<TAB>
+make deploy ENV=<TAB>
 ```
 
 ## Troubleshooting

--- a/.rhiza/completions/rhiza-completion.bash
+++ b/.rhiza/completions/rhiza-completion.bash
@@ -56,7 +56,7 @@ _rhiza_make_completion() {
     fi
 
     # Add common make variables that can be overridden
-    local vars="DRY_RUN=1 BUMP=patch BUMP=minor BUMP=major ENV=dev ENV=staging ENV=prod"
+    local vars="DRY_RUN=1 ENV=dev ENV=staging ENV=prod"
     opts="$opts $vars"
 
     # Generate completions

--- a/.rhiza/completions/rhiza-completion.zsh
+++ b/.rhiza/completions/rhiza-completion.zsh
@@ -92,9 +92,6 @@ _rhiza_make() {
     # Common make variables
     variables=(
         'DRY_RUN=1:preview mode without making changes'
-        'BUMP=patch:bump patch version'
-        'BUMP=minor:bump minor version'
-        'BUMP=major:bump major version'
         'ENV=dev:development environment'
         'ENV=staging:staging environment'
         'ENV=prod:production environment'

--- a/.rhiza/make.d/quality.mk
+++ b/.rhiza/make.d/quality.mk
@@ -5,7 +5,7 @@
 LICENSE_FAIL_ON ?= GPL;LGPL;AGPL
 
 # Declare phony targets (they don't produce files)
-.PHONY: all deptry fmt license todos suppression-audit semgrep
+.PHONY: all deptry fmt license todos semgrep
 
 ##@ Quality and Formatting
 all: fmt deptry test docs-coverage security license typecheck rhiza-test ## run all CI targets locally
@@ -51,10 +51,6 @@ todos: ## search and report all TODO/FIXME/HACK comments in the codebase
 		awk -F: '{ printf "${YELLOW}%s${RESET}:${GREEN}%s${RESET}: %s\n", $$1, $$2, substr($$0, index($$0,$$3)) }' || \
 		printf "${GREEN}[SUCCESS] No TODO/FIXME/HACK comments found!${RESET}\n"
 	@printf "\n${BLUE}[INFO] Search complete.${RESET}\n"
-
-suppression-audit: install-uv ## scan codebase for inline suppressions and report (grade, detail, histogram)
-	@printf "${BLUE}[INFO] Running suppression audit...${RESET}\n"
-	@${UVX_BIN} "rhiza-tools>=0.8.1" suppression-audit
 
 semgrep: install ## run Semgrep static analysis
 	@printf "${BLUE}[INFO] Running Semgrep...${RESET}\n"

--- a/.rhiza/make.d/test.mk
+++ b/.rhiza/make.d/test.mk
@@ -110,16 +110,9 @@ typecheck: install ## run ty and/or mypy type checking (TYPECHECKER=ty|mypy|both
 	    ;; \
 	esac
 
-# Extra flags forwarded to pip-audit (e.g. --ignore-vuln CVE-XXXX-YYYY)
-PIP_AUDIT_ARGS ?=
-
-# The 'security' target performs security vulnerability scans.
-# 1. Runs pip-audit via `rhiza-tools pip-audit` (tiered policy): fails on runtime
-#    dep CVEs, warns on tooling (pip/setuptools/wheel).
-# 2. Runs bandit to find common security issues in Python source folders that exist.
-security: install ## run security scans (pip-audit and bandit)
-	@printf "${BLUE}[INFO] Running pip-audit for dependency vulnerabilities...${RESET}\n"
-	@${UVX_BIN} "rhiza-tools>=0.8.1" pip-audit ${PIP_AUDIT_ARGS}
+# The 'security' target runs bandit to find common security issues in the
+# Python source folders that exist.
+security: install ## run security scans (bandit)
 	@bandit_paths=""; \
 	if [ -d "${SOURCE_FOLDER}" ]; then \
 	  bandit_paths="${SOURCE_FOLDER}"; \
@@ -135,7 +128,6 @@ security: install ## run security scans (pip-audit and bandit)
 # 1. Installs benchmarking dependencies (pytest-benchmark, pygal).
 # 2. Executes benchmarks found in the benchmarks/ subfolder.
 # 3. Generates histograms and JSON results.
-# 4. Runs a post-analysis script to process the results.
 benchmark:: install ## run performance benchmarks
 	@if [ -d "${TESTS_FOLDER}/benchmarks" ]; then \
 	  printf "${BLUE}[INFO] Running performance benchmarks...${RESET}\n"; \
@@ -144,7 +136,6 @@ benchmark:: install ## run performance benchmarks
 	  		--benchmark-only \
 			--benchmark-histogram=_tests/benchmarks/histogram \
 			--benchmark-json=_tests/benchmarks/results.json; \
-	  ${UVX_BIN} "rhiza-tools>=0.2.3" analyze-benchmarks --benchmarks-json _tests/benchmarks/results.json --output-html _tests/benchmarks/report.html; \
 	else \
 	  printf "${YELLOW}[WARN] Benchmarks folder not found, skipping benchmarks${RESET}\n"; \
 	fi

--- a/.rhiza/rhiza.mk
+++ b/.rhiza/rhiza.mk
@@ -55,21 +55,10 @@ RESET := \033[0m
 # Declare phony targets (they don't produce files)
 .PHONY: \
 	help \
-	post-bump \
 	post-install \
-	post-release \
-	post-sync \
-	post-validate \
-	pre-bump \
 	pre-install \
-	pre-release \
-	pre-sync \
-	pre-validate \
 	print-logo \
 	readme \
-	summarise-sync \
-	sync \
-	validate \
 	version-matrix \
 	ci-os-matrix
 
@@ -82,15 +71,6 @@ VENV ?= .venv
 # Read Python version from .python-version (single source of truth)
 PYTHON_VERSION ?= $(strip $(shell cat .python-version 2>/dev/null || echo "3.13"))
 export PYTHON_VERSION
-
-# Read Rhiza version from .rhiza/.rhiza-version (single source of truth for rhiza-tools)
-RHIZA_VERSION ?= $(shell cat .rhiza/.rhiza-version 2>/dev/null || echo "0.10.2")
-export RHIZA_VERSION
-
-# Default sync schedule (cron expression for GitHub Actions sync workflow)
-# Override in your root Makefile to customise when sync runs.
-# Example: RHIZA_SYNC_SCHEDULE = 0 9 * * 1-5  (weekdays at 9 AM UTC)
-RHIZA_SYNC_SCHEDULE ?= 0 0 * * 1
 
 export UV_NO_MODIFY_PATH := 1
 export UV_VENV_CLEAR := 1
@@ -135,21 +115,7 @@ endef
 export RHIZA_LOGO
 
 # Declare phony targets for Rhiza Core
-.PHONY: print-logo sync sync-experimental materialize validate readme pre-sync post-sync pre-validate post-validate _apply-sync-schedule
-
-# Hook targets (double-colon rules allow multiple definitions)
-# Note: pre-install/post-install are defined in bootstrap.mk
-# Note: pre-bump/post-bump/pre-release/post-release are defined in releasing.mk
-pre-sync:: ; @:
-post-sync:: ; @:
-pre-validate:: ; @:
-post-validate:: ; @:
-
-# Detected once at parse time: non-empty when origin is the jebel-quant/rhiza
-# mother repository, which by design has no template.yml. The sync/summarise/
-# validate targets are no-ops there. Evaluated a single time and reused so the
-# origin regex lives in exactly one place.
-IS_MOTHER_REPO := $(shell git remote get-url origin 2>/dev/null | grep -iqE 'jebel-quant/rhiza(\.git)?$$' && echo 1)
+.PHONY: print-logo
 
 ##@ Rhiza Workflows
 
@@ -157,53 +123,12 @@ print-logo:
 	@printf "${BLUE}$$RHIZA_LOGO${RESET}\n"
 
 
-sync: pre-sync ## sync with template repository as defined in .rhiza/template.yml
-	@if [ -n "$(IS_MOTHER_REPO)" ]; then \
-		printf "${BLUE}[INFO] Skipping sync in rhiza repository (no template.yml by design)${RESET}\n"; \
-	else \
-		$(MAKE) install-uv && \
-		${UVX_BIN} "rhiza==$(RHIZA_VERSION)" sync . && \
-		$(MAKE) _apply-sync-schedule; \
-	fi
-	@$(MAKE) post-sync
-
-_apply-sync-schedule: ## (internal) apply RHIZA_SYNC_SCHEDULE override to GitHub Actions sync workflow
-	@if [ "$(RHIZA_SYNC_SCHEDULE)" != "0 0 * * 1" ] && [ -f .github/workflows/rhiza_sync.yml ]; then \
-		sed -i.bak "s|cron: '[^']*'|cron: '$(RHIZA_SYNC_SCHEDULE)'|" .github/workflows/rhiza_sync.yml && rm -f .github/workflows/rhiza_sync.yml.bak; \
-		printf "${BLUE}[INFO] Applied custom sync schedule: $(RHIZA_SYNC_SCHEDULE)${RESET}\n"; \
-	fi
-
-materialize: ## [DEPRECATED] use 'make sync' instead — materialize --force is now sync
-	@printf "${YELLOW}[WARN] 'make materialize' is deprecated and will be removed in a future release.${RESET}\n"
-	@printf "${YELLOW}[WARN] Please use 'make sync' instead (e.g. 'materialize --force' is now 'make sync').${RESET}\n"
-	@$(MAKE) sync
-
-summarise-sync: install-uv ## summarise differences created by sync with template repository
-	@if [ -n "$(IS_MOTHER_REPO)" ]; then \
-		printf "${BLUE}[INFO] Skipping summarise-sync in rhiza repository (no template.yml by design)${RESET}\n"; \
-	else \
-		$(MAKE) install-uv; \
-		${UVX_BIN} "rhiza==$(RHIZA_VERSION)" summarise .; \
-	fi
-
 rhiza-test: install ## run rhiza's own tests (if any)
 	@if [ -d ".rhiza/tests" ]; then \
 		${UV_BIN} run --with pytest --with pytest-timeout --with python-dotenv --with packaging pytest .rhiza/tests; \
 	else \
 		printf "${YELLOW}[WARN] No .rhiza/tests directory found, skipping rhiza-tests${RESET}\n"; \
 	fi
-
-validate: pre-validate rhiza-test ## validate project structure against template repository as defined in .rhiza/template.yml
-	@if [ -n "$(IS_MOTHER_REPO)" ]; then \
-		printf "${BLUE}[INFO] Skipping validate in rhiza repository (no template.yml by design)${RESET}\n"; \
-	else \
-		$(MAKE) install-uv; \
-		${UVX_BIN} "rhiza==$(RHIZA_VERSION)" validate .; \
-	fi
-	@$(MAKE) post-validate
-
-readme: install-uv ## update README.md with current Makefile help output
-	@${UVX_BIN} "rhiza-tools>=0.2.0" update-readme
 
 ##@ Meta
 
@@ -213,9 +138,6 @@ help: print-logo ## Display this help message
 	+@printf "$(BOLD)Targets:$(RESET)\n"
 	+@awk 'BEGIN {FS = ":.*##"; printf ""} /^[a-zA-Z_-]+:.*?##/ { printf "  $(BLUE)%-20s$(RESET) %s\n", $$1, $$2 } /^##@/ { printf "\n$(BOLD)%s$(RESET)\n", substr($$0, 5) }' $(MAKEFILE_LIST)
 	+@printf "\n"
-
-version-matrix: install-uv ## Emit the list of supported Python versions from pyproject.toml
-	@${UVX_BIN} "rhiza-tools>=0.2.2" version-matrix
 
 ci-os-matrix: ## Emit GitHub CI OSes (RHIZA_CI_OS_MATRIX as JSON array, default ["ubuntu-latest"])
 	@$(info $(or $(RHIZA_CI_OS_MATRIX),["ubuntu-latest"]))

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,10 +1,12 @@
-sha: 8e6a8d48b98db05a10b7da67d26fac7ed54508c8
+sha: e5d7005e2d9fc3d5a23b96d13b203b4f2afe3cce
 repo: jebel-quant/rhiza
 host: github
-ref: v1.1.3
+ref: v1.2.5
 include: []
 exclude: []
 templates: []
+profiles:
+- github-project
 files:
 - .bandit
 - .editorconfig
@@ -18,6 +20,7 @@ files:
 - .github/pull_request_template.md
 - .github/release.yml
 - .github/rulesets/main-branch-protection.json
+- .github/rulesets/tag-protection.json
 - .github/secret_scanning.yml
 - .github/workflows/rhiza_benchmark.yml
 - .github/workflows/rhiza_book.yml
@@ -28,7 +31,6 @@ files:
 - .github/workflows/rhiza_mutation.yml
 - .github/workflows/rhiza_release.yml
 - .github/workflows/rhiza_scorecard.yml
-- .github/workflows/rhiza_sync.yml
 - .github/workflows/rhiza_weekly.yml
 - .gitignore
 - .pre-commit-config.yaml
@@ -36,7 +38,6 @@ files:
 - .rhiza/.cfg.toml
 - .rhiza/.env
 - .rhiza/.gitignore
-- .rhiza/.rhiza-version
 - .rhiza/assets/rhiza-logo.svg
 - .rhiza/completions/README.md
 - .rhiza/completions/rhiza-completion.bash
@@ -50,7 +51,6 @@ files:
 - .rhiza/make.d/github.mk
 - .rhiza/make.d/marimo.mk
 - .rhiza/make.d/quality.mk
-- .rhiza/make.d/releasing.mk
 - .rhiza/make.d/test.mk
 - .rhiza/rhiza.mk
 - .rhiza/semgrep.yml
@@ -68,7 +68,5 @@ files:
 - docs/mkdocs-base.yml
 - pytest.ini
 - ruff.toml
-profiles:
-- github-project
-synced_at: '2026-07-11T08:07:27Z'
+synced_at: '2026-07-30T09:51:47Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.1.3"
+ref: "v1.2.5"
 
 profiles:
   - github-project

--- a/.rhiza/tests/test_pyproject.py
+++ b/.rhiza/tests/test_pyproject.py
@@ -140,7 +140,7 @@ class TestProjectUrls:
 
 
 class TestProjectClassifiers:
-    """Tests for [project].classifiers — Python version and licence entries."""
+    """Tests for [project].classifiers — Python version entries."""
 
     @pytest.fixture
     def classifiers(self, project: dict) -> list[str]:
@@ -157,10 +157,17 @@ class TestProjectClassifiers:
             "classifiers must include at least one 'Programming Language :: Python :: 3.X' entry"
         )
 
-    def test_license_classifier_present(self, classifiers: list[str]) -> None:
-        """At least one 'License :: ' classifier must be present."""
+    def test_no_license_classifier(self, project: dict) -> None:
+        """No deprecated 'License :: ' classifier may be present.
+
+        PyPI has deprecated the ``License ::`` trove classifiers in favor of the SPDX
+        ``license`` expression field, so the shipped pyproject must not declare one.
+        """
+        classifiers = project.get("classifiers", [])
         license_classifiers = [c for c in classifiers if c.startswith("License ::")]
-        assert len(license_classifiers) >= 1, "classifiers must include at least one 'License :: ' entry"
+        assert not license_classifiers, (
+            f"classifiers must not include any deprecated 'License :: ' entry; found {license_classifiers}"
+        )
 
 
 class TestDependencyGroups:

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,8 +3,7 @@
 #
 # Maximum line length for the entire project
 line-length = 120
-# Target Python version
-target-version = "py311"
+# Target Python version is inferred from project.requires-python.
 
 # Exclude directories with Jinja template variables in their names
 exclude = ["**/[{][{]*/", "**/*[}][}]*/"]


### PR DESCRIPTION
## Rhiza template sync

- **Template:** `jebel-quant/rhiza`
- **Ref:** `v1.1.3` → **`v1.2.5`** (upstream commit `e5d7005e2d9f`)

### What changed

24 template-owned files updated (workflows, `.rhiza/` make fragments, completions,
`rhiza.mk`, `.pre-commit-config.yaml`, `ruff.toml`, rulesets, `template.lock`),
including one new file: `.github/rulesets/tag-protection.json`.

### Conflicts

10 files came back with conflict markers — all ten `.github/workflows/rhiza_*.yml`.
Every block was resolved by **taking the upstream (template) side**, since a
rhiza-managed file is the template's to own.

### Left in the working tree (not committed)

The sync removed three paths from disk that the new `template.lock` does not list,
so they were deliberately **left unstaged** rather than folded into this PR:

- `.github/workflows/rhiza_sync.yml`
- `.rhiza/.rhiza-version`
- `.rhiza/make.d/releasing.mk`

v1.2.5 no longer ships these. Decide separately whether to commit their removal.

### Gates

**No quality gates were run** — `/update` only syncs. Run `/rhiza:quality` for a
scorecard, or `/rhiza:status` to see what is now synced.
