### PR TITLE
chore: close the three /rhiza:quality findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The pin lives in `.rhiza/template.yml`:
 
 ```yaml
 repository: "jebel-quant/rhiza"
-ref: "v1.0.1"
+ref: "v1.3.3"
 profiles:
   - github-project
 ```
@@ -56,7 +56,10 @@ Synced from the template — treat as read-only. Highlights from
   private modules: `_kkt.py` (`active_set`/`solve_kkt`), `_events.py`
   (`event_ratios`/`ineq_event_ratios`), and `_projection.py` (`project_feasible`
   and its capped-simplex/alternating workers); `cla.py` is the orchestrator that
-  wires them into the `ParametricProblem` hooks.
+  wires them into the `ParametricProblem` hooks. `lasso.py` is factored the same
+  way, over `_lasso.py` (the `LassoSegment`/`LassoState` kernel with
+  `scan_events`/`solve_segment`) and `_lasso_validate.py` (the design, operator
+  and constraint input validators).
 - `tests/` — the project test suite (unit, property-based `test_properties.py`,
   fuzz `tests/fuzz/`, benchmarks `tests/benchmarks/`). **Note:**
   `.rhiza/tests/` is Rhiza-owned and tests the template itself, not this library.
@@ -81,9 +84,8 @@ and pass the right flags. Useful targets:
 | `make fmt` | pre-commit hooks: ruff format/check, markdownlint, bandit, actionlint, interrogate, secrets |
 | `make typecheck` | `ty` + `mypy --strict` over `src/` |
 | `make docs-coverage` | interrogate docstring coverage |
-| `make deptry` | unused/missing/misplaced dependency analysis |
+| `make deps` | unused/missing/misplaced dependency analysis (the old `make deptry` is deprecated) |
 | `make security` | pip-audit + bandit |
-| `make validate` | validate project structure against `.rhiza/template.yml` |
 | `make test` | full suite **with** the coverage gate |
 
 `make test` enforces `COVERAGE_FAIL_UNDER` (currently **100%**). Coverage on

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ I gave the plenary talk at [EQD's Singapore conference](https://tschm.github.io/
 
 The Markowitz problem is a quadratic program parametrized by a return target λ:
 
-```
+```text
 min  wᵀΣw - λ · μᵀw
 s.t. Aw = b,  Gw ≤ h,  lb ≤ w ≤ ub
 ```
@@ -57,7 +57,7 @@ negated row). As λ sweeps from ∞ (maximize return) down to 0 (minimize varian
 traces the entire efficient frontier. The key insight is that **between consecutive
 events, the optimal weights are a linear function of λ**:
 
-```
+```text
 w(λ) = α + λ · β
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,15 @@ ignore-nested-classes = true
 module = ["plotly.*"]
 ignore_missing_imports = true
 
+# Tests are organised by behaviour in a flat `tests/`, not mirrored per module, and
+# the pure numeric kernels are exercised through the orchestrators that wire them up.
+# Per-module coverage is guaranteed by the stricter mechanism instead: `make test`
+# runs with COVERAGE_FAIL_UNDER=100, so a module with no exercising test fails CI
+# regardless of what any test file is named.
+[tool.check_test_layout]
+enforce = false
+reason = "Flat behaviour-oriented tests; private kernels (_kkt, _events, _projection, _lasso, _lasso_validate) are covered through cla.py/lasso.py, and per-module coverage is enforced by the 100% COVERAGE_FAIL_UNDER gate."
+
 [tool.deptry.per_rule_ignores]
 DEP002 = ["kaleido"]
 


### PR DESCRIPTION
Closes the three findings from a `/rhiza:quality` run (full mode, template
v1.3.3). All three are documentation-of-intent gaps — **no source or test
changes**, 17 insertions across three files.

## What changed

### 1. Declare the test-layout opt-out — `pyproject.toml` (#844)

`check_test_layout.py` exited 1 with 24 violations: it expects
`src/cvxcla/cla.py` → `tests/cvxcla/test_cla.py`, and this repo uses a flat
`tests/test_cla.py`. The 24 split into 13 "missing mirror" and 11 "orphan test
file" entries, which are the same eleven files counted from both ends, plus the
five private kernels tested through their orchestrators.

Both deviations are deliberate:

- Tests are organised by behaviour, not mirrored per module.
- The pure numeric kernels — `_kkt`, `_events`, `_projection`, `_lasso`,
  `_lasso_validate` — are exercised through the `cla.py` / `lasso.py`
  orchestrators that wire them up, which asserts behaviour rather than pinning
  internals.

Per-module coverage is already guaranteed by a strictly stronger mechanism:
`COVERAGE_FAIL_UNDER = 100` fails CI for any unexercised module regardless of
what a test file is named. Declaring `[tool.check_test_layout]` records that
reasoning, so the next contributor doesn't "fix" the gate by moving eleven
files for no benefit.

### 2. Refresh stale references — `CLAUDE.md` (#845)

Four drifted facts in the doc that holds the Rhiza-owned / locally-owned split:

| Was | Now |
| --- | --- |
| `ref: "v1.0.1"` | `ref: "v1.3.3"` — matches `.rhiza/template.yml` and `.rhiza/template.lock` |
| A `validate` row in the command table | Removed — the template dropped that target at v1.2.1 |
| The `deptry` target | The `deps` target, with the deprecation noted |
| Module list omitted `_lasso.py`, `_lasso_validate.py` | Both documented, mirroring how the CLA-side kernels already are |

The version pin mattered most: `CLAUDE.md` presents itself as the place to
learn which files are Rhiza-owned, so a reader trusting the `v1.0.1` block was
reasoning about a template three minor versions behind the synced one.

### 3. Tag the untagged README fences — `README.md` (#846)

Lines 49 and 60 carried no language, so nothing could check them — not
markdownlint, not the doc-example checker, not a reader's highlighter. Both are
math notation (the parametrized QP statement and `w(λ) = α + λ · β`), so `text`
records that they are deliberately non-executable rather than tagged by
accident.

## Verification

Every gate re-run after the change:

| Gate | Result |
| --- | --- |
| `fmt` | PASS — 21 hooks |
| `typecheck` | PASS — `ty` + `mypy --strict`, 15 modules |
| `docs-coverage` | PASS — 477/477, 100.0% |
| `deps` | PASS — no dependency issues |
| `security` | PASS — bandit clean |
| `rhiza-test` | PASS — 40/40 |
| `test` | PASS — 201 tests, **100.00%** coverage (812/812) |
| `check_test_layout.py` | exit 0 — was exit 1 with 24 violations |
| `check_doc_examples.py` | exit 0 — `violations: []`, `notes: []` |

That takes the repo from 7/8 to **8/8 gates green**.

Closes #844
Closes #845
Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
