### PR TITLE
chore: drop the literal % from the check_test_layout reason

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ ignore_missing_imports = true
 # regardless of what any test file is named.
 [tool.check_test_layout]
 enforce = false
-reason = "Flat behaviour-oriented tests; private kernels (_kkt, _events, _projection, _lasso, _lasso_validate) are covered through cla.py/lasso.py, and per-module coverage is enforced by the 100% COVERAGE_FAIL_UNDER gate."
+reason = "Flat behaviour-oriented tests; private kernels (_kkt, _events, _projection, _lasso, _lasso_validate) are covered through cla.py/lasso.py, and per-module coverage is enforced by the full COVERAGE_FAIL_UNDER gate."
 
 [tool.deptry.per_rule_ignores]
 DEP002 = ["kaleido"]


### PR DESCRIPTION
## Why

`radon` reads `pyproject.toml` into a `configparser` with interpolation enabled, so **any** `%` in a value aborts it before it analyses a single module:

```
ValueError: invalid interpolation syntax in 'Flat behaviour-oriented tests; ... enforced by the 100% COVERAGE_FAIL_UNDER gate.' at position 184
```

That made `uvx radon cc src -a -s` and `uvx radon mi src -s` unusable inside the repo — which is exactly what `/rhiza:quality`'s design analysis runs to produce the complexity marks. Found while running that command; the only workaround was copying `src/` outside the repo.

## What

The single `%` in the file was the `100%` inside the `[tool.check_test_layout]` reason string. Reworded to "full". The comment block directly above (lines 72-76) already states `COVERAGE_FAIL_UNDER=100` explicitly, so nothing is lost.

## Behaviour

Unchanged. The `reason` field is prose that `check_test_layout.py` only echoes back in its OK message.

## Verification

- `uvx radon cc src -a -s` now runs in-repo — 113 blocks, average complexity **A (2.08)**, nothing at C or worse
- `uvx radon mi src -s` — every module rank **A**
- `check_test_layout.py` still reports the documented opt-out
- `make rhiza-test` — 40 passed (includes the `[project]` structure gate)
- `make fmt` — all hooks pass, including `Validate pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)