### PR TITLE
chore: prune exclude entries the template no longer ships

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -15,8 +15,6 @@ exclude:
   - .github/workflows/rhiza_mutation.yml
   # Repo-level GitHub metadata is owned here, not by the template.
   - .github/CONFIG.md
-  - .github/DISCUSSION_TEMPLATE
-  - .github/ISSUE_TEMPLATE
 
 # NOT excluded, on purpose:
 #   .github/workflows/rhiza_fuzzing.yml — FUZZING_ENABLED=true and


### PR DESCRIPTION
Removes `exclude:` entries that no longer match anything.

The template dropped both directories in **v1.5.0**:

- `bundles/github/.github/ISSUE_TEMPLATE` — rhiza #1567 (`a34059d`)
- `bundles/github/.github/DISCUSSION_TEMPLATE` — rhiza #1566 (`20e0ffa`)

This repo is pinned at v1.5.x, so the sync never delivers those paths and the entries match nothing. `exclude:` is matched against destination paths, and an entry that resolves to nothing is silently inert — dead config that reads like an active decision.

Only `.rhiza/template.yml` is touched; no template-owned file and no repo source is in this PR. Verified with `git tag --contains`: both deletions are in v1.5.0 and v1.5.1, and `git ls-tree v1.5.1` reports 0 files for each directory.

**No gates were run.** Run `/rhiza:quality` for a scorecard.
