### PR TITLE
chore: sync the legal bundle, keeping this repo's LICENSE

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -4,10 +4,19 @@ ref: "v1.5.0"
 profiles:
   - github-project
 
+templates:
+  # SECURITY.md, CODE_OF_CONDUCT.md and CONTRIBUTING.md. LICENSE is excluded below.
+  - legal
+
 # exclude: is matched against DESTINATION paths (where the file lands here),
 # not against clone-relative paths inside the template. A `bundles/...` entry
 # matches nothing, silently.
 exclude:
+  # The template's LICENSE. `legal` is synced for SECURITY.md and the community docs,
+  # but the licence text is this repository's own: the bundle ships MIT under
+  # "Copyright (c) 2025 Jebel Quant Research", which is not this repo's holder.
+  - LICENSE
+
   # MUTATION_ENABLED is not set on this repo and the gate lives in the caller,
   # so the workflow only ever starts in order to skip. Note the file is deleted
   # too: re-enabling mutation testing later needs the workflow back, not just


### PR DESCRIPTION
Adds the template's `legal` bundle to `templates:`, with `LICENSE` excluded.

**What this repo starts receiving** (on the next sync): `SECURITY.md`, `.rhiza/CODE_OF_CONDUCT.md`, `.rhiza/CONTRIBUTING.md`.

**What it keeps:** `LICENSE`. The bundle ships MIT under `Copyright (c) 2025 Jebel Quant Research`, which is not this repository's holder, so the licence text stays repo-owned. Without that exclude the sync would rewrite it.

Config only — this PR touches `.rhiza/template.yml` and nothing else. The three files above arrive when the sync next runs (`/rhiza:update`), not in this PR.

**No gates were run.** Run `/rhiza:quality` for a scorecard.
