### PR TITLE
chore: update rhiza to v1.5.1

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.5.1
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.5.1
     secrets: inherit

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.5.1
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.0
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.5.1
     secrets: inherit

--- a/.rhiza/CODE_OF_CONDUCT.md
+++ b/.rhiza/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+## Purpose
+
+This code of conduct outlines expectations for behaviour when participating in the project with the aim of fostering a constructive and professional engineering environment.
+
+## Expected Behaviour
+
+Participants are expected to:
+
+- Be respectful in communication and collaboration.
+- Focus on technical topics and project goals.
+- Accept constructive feedback gracefully and offer it in kind.
+- Assume good intentions from others and engage with a problem-solving mindset.
+- Use appropriate language and conduct in all community spaces.
+
+## Scope
+
+This Code of Conduct applies in all project spaces—online and offline—and also applies when individuals are representing the project in public spaces.
+
+## Enforcement
+
+Project maintainers are responsible for enforcing the code and may take proportionate corrective action in response to unexpected behaviour.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), with modifications for brevity and neutrality.

--- a/.rhiza/CONTRIBUTING.md
+++ b/.rhiza/CONTRIBUTING.md
@@ -1,0 +1,184 @@
+# Contributing
+
+This document is a guide to contributing to the project.
+
+We welcome all contributions. You don't need to be an expert
+to help out.
+
+## Checklist
+
+Contributions are made through
+[pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+Before sending a pull request, make sure you do the following:
+
+- If setup or tooling fails, run `make doctor` first to validate prerequisites and
+  follow the install guidance.
+- Run `make fmt` to make sure your code adheres to our [coding style](#code-style)
+and all tests pass.
+- [Write unit tests](#writing-unit-tests) for new functionality added.
+
+## Building from source
+
+You'll need to build the project locally to start editing code.
+To install from source, clone the repository from GitHub, 
+navigate to its root, and run the following command:
+
+```bash
+make install
+```
+
+### Windows quick-start (WSL)
+
+The Makefile system requires GNU Make and a POSIX shell, so native Windows
+shells (PowerShell, cmd.exe, Git Bash) fail fast with an error. Use the
+Windows Subsystem for Linux instead:
+
+1. Install WSL with an Ubuntu distribution (PowerShell, as administrator):
+
+   ```bash
+   wsl --install -d Ubuntu
+   ```
+
+2. Inside the Ubuntu shell, install the prerequisites that `make doctor` checks
+   for (GNU Make and git; `make install` provisions `uv` itself):
+
+   ```bash
+   sudo apt-get update && sudo apt-get install -y make git curl
+   ```
+
+3. Clone the repository **inside the WSL filesystem** (e.g. `~/projects`), not
+   under `/mnt/c/...` — cross-filesystem I/O is dramatically slower and can
+   break file-permission assumptions:
+
+   ```bash
+   git clone https://github.com/jebel-quant/rhiza.git ~/projects/rhiza
+   cd ~/projects/rhiza && make install
+   ```
+
+4. Run `make doctor` to confirm the toolchain is complete.
+
+### Optional uv dependency groups
+
+For faster, focused installs you can sync only the dependency groups you need:
+
+```bash
+uv sync --group test        # test tooling
+uv sync --group docs        # docs/notebook stack (marimo, numpy, pandas, plotly)
+uv sync --all-groups        # full development environment
+```
+
+There is no `lint` group: `make fmt` runs the hooks through prek, which provisions each
+linter itself, so there is nothing for such a group to install.
+
+## Contributing code
+
+To contribute to the project, send us pull requests.
+For those new to contributing, check out GitHub's
+[guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
+
+Once you've made your pull request, a member of the
+development team will assign themselves to review it.
+You might have a few
+back-and-forths with your reviewer before it is accepted,
+which is completely normal.
+Your pull request will trigger continuous integration tests
+for many different
+Python versions and different platforms. If these tests start failing,
+please
+fix your code and send another commit, which will re-trigger the tests.
+
+If you'd like to add a new feature, please propose your
+change in a GitHub issue to make sure
+that your priorities align with ours.
+
+If you'd like to contribute code but don't know where to start,
+try one of the
+following:
+
+- Read the source and enhance the documentation,
+  or address TODOs
+- Browse the open issues,
+  and look for the issues tagged "help wanted".
+
+## Commit conventions
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). Every commit message must have a
+structured prefix so tooling can generate changelogs automatically.
+
+### Format
+
+```
+<type>(<scope>): <short summary>
+```
+
+`scope` is optional but encouraged when the change is limited to a specific area.
+
+### Types
+
+| Type       | When to use                                      |
+|------------|--------------------------------------------------|
+| `feat`     | New feature or capability                        |
+| `fix`      | Bug fix                                          |
+| `docs`     | Documentation only                               |
+| `refactor` | Code change that is neither a fix nor a feature  |
+| `test`     | Adding or updating tests                         |
+| `ci`       | CI / build system changes                        |
+| `chore`    | Maintenance tasks (deps, tooling, config)        |
+| `perf`     | Performance improvement                          |
+| `security` | Security fix or hardening                        |
+
+### Examples
+
+```
+feat(templates): add devcontainer template for Python 3.13
+fix: resolve path issue in bootstrap script
+docs: update CONTRIBUTING with commit conventions
+ci: cache uv dependencies in GitHub Actions
+```
+
+### Breaking changes
+
+Append `!` after the type/scope and add a `BREAKING CHANGE:` footer:
+
+```
+feat!: rename make target from `book` to `docs`
+
+BREAKING CHANGE: the `sync` make target no longer exists; use `/rhiza:update`.
+```
+
+## Code style
+
+We use ruff to enforce our Python coding style.
+Before sending us a pull request, navigate to the project 
+root and run
+
+```bash
+make fmt
+```
+
+to make sure that your changes abide by our style conventions.
+Please fix any errors that are reported before sending
+the pull request.
+
+## Writing unit tests
+
+Most code changes will require new unit tests.
+Even bug fixes require unit tests,
+since the presence of bugs usually indicates insufficient tests.
+When adding tests, try to find a file in which your tests should belong;
+if you're testing a new feature, you might want to create a new test file.
+
+We use the popular Python [pytest](https://docs.pytest.org/en/) framework for our
+tests.
+
+## Running unit tests
+
+We use `pytest` to run our unit tests.
+To run all unit tests run the following command:
+
+```bash
+make test
+```
+
+Please make sure that your change doesn't cause any
+of the unit tests to fail.

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,14 +1,14 @@
-sha: 8ef5b50907aaf9c29aaf24c8c8de34a015f486a6
+sha: de568b1e79e5871c58b4349762ce9dfd31d73e99
 repo: jebel-quant/rhiza
 host: github
-ref: v1.5.0
+ref: v1.5.1
 include: []
 exclude:
+- LICENSE
 - .github/workflows/rhiza_mutation.yml
 - .github/CONFIG.md
-- .github/DISCUSSION_TEMPLATE
-- .github/ISSUE_TEMPLATE
-templates: []
+templates:
+- legal
 profiles:
 - github-project
 files:
@@ -30,8 +30,11 @@ files:
 - .gitignore
 - .pre-commit-config.yaml
 - .python-version
+- .rhiza/CODE_OF_CONDUCT.md
+- .rhiza/CONTRIBUTING.md
 - .rhiza/semgrep.yml
 - Makefile
+- SECURITY.md
 - cliff.toml
 - docs/assets/rhiza-logo.svg
 - docs/development/MARIMO.md
@@ -41,5 +44,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-22T11:29:53Z'
+synced_at: '2026-08-22T18:21:36Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.5.0"
+ref: "v1.5.1"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Rhiza template update

`jebel-quant/rhiza`: **v1.5.0 → v1.5.1**

- 32 template files considered, **10 changed**: 7 `rhiza_*.yml` reusable-workflow pins bumped to `@v1.5.1`, plus `.rhiza/template.lock`.
- `.rhiza/CODE_OF_CONDUCT.md` and `.rhiza/CONTRIBUTING.md` were **restored** — they were missing from the target and the template still owns them.
- **No conflicts** — the sync completed clean (exit 0).
- Nothing was left unstaged; this branch contains template-owned files only.

**No gates were run.** Run `/rhiza:quality` for a scorecard, `/rhiza:status` to see what is now synced.
