### PR TITLE
chore: drop the exclude entries for the retired mutation/fuzzing workflows

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -17,15 +17,5 @@ exclude:
   # "Copyright (c) 2025 Jebel Quant Research", which is not this repo's holder.
   - LICENSE
 
-  # MUTATION_ENABLED is not set on this repo and the gate lives in the caller,
-  # so the workflow only ever starts in order to skip. Note the file is deleted
-  # too: re-enabling mutation testing later needs the workflow back, not just
-  # the repository variable.
-  - .github/workflows/rhiza_mutation.yml
   # Repo-level GitHub metadata is owned here, not by the template.
   - .github/CONFIG.md
-
-# NOT excluded, on purpose:
-#   .github/workflows/rhiza_fuzzing.yml — FUZZING_ENABLED=true and
-#   "(RHIZA) FUZZING" passes on every PR and push (~53s). Excluding it would
-#   delete a live gate; the sync bumps its pin instead.


### PR DESCRIPTION
rhiza v1.5.0 retired `.github/workflows/rhiza_fuzzing.yml` (#1568) and `.github/workflows/rhiza_mutation.yml` (#1572), and stopped offering mutation testing in the ecosystem at all (#1492). Nothing under `bundles/` ships either path now, so excluding them declines a file the sync can no longer deliver.

This drops the two entries and the comment paragraphs that existed only to justify them. Where a comment also explained why the *other* workflow was deliberately left in the sync, that note goes too — it describes a live gate that no longer exists.

**No CI behaviour changes.** Neither workflow is delivered with or without these entries.

**This does not delete any leftover workflow file.** Orphan cleanup only considers paths recorded in `.rhiza/template.lock`'s `files:` list, and these are absent from it, so a copy still present in `.github/workflows/` stays put either way. That is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)