### PR TITLE
fix: repair the dead README links the weekly link check reports

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,6 @@
+# Links the weekly link check must skip.
+#
+# rand.org sits behind CloudFront, which answers any non-browser client -- the
+# link checker included -- with 403. The Markowitz memorandum RM1438 is alive and
+# reachable in a browser, so the 403 is a bot block rather than a dead link.
+https://www\.rand\.org/

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 **Quick Links:**
 [📖 Documentation](https://www.cvxgrp.org/cvxcla) •
 [🐛 Report Bug](https://github.com/cvxgrp/cvxcla/issues) •
-[💡 Request Feature](https://github.com/cvxgrp/cvxcla/issues) •
-[💬 Discussions](https://github.com/cvxgrp/cvxcla/discussions)
+[💡 Request Feature](https://github.com/cvxgrp/cvxcla/issues)
 
 ---
 
@@ -339,8 +338,11 @@ make fmt
 
 ## 📖 Documentation
 
-- [Online Documentation](https://www.cvxgrp.org/cvxcla/book)
-- [API Reference](https://www.cvxgrp.org/cvxcla/pdoc/)
+- [Online Documentation](https://www.cvxgrp.org/cvxcla/)
+- [Factor backend](https://www.cvxgrp.org/cvxcla/factor/)
+- [Notebooks](https://www.cvxgrp.org/cvxcla/notebooks/cla.html)
+- [Test report](https://www.cvxgrp.org/cvxcla/reports/html-report/report.html)
+- [Coverage report](https://www.cvxgrp.org/cvxcla/reports/html-coverage/index.html)
 
 ## 👥 Contributing
 


### PR DESCRIPTION
The weekly `(RHIZA) WEEKLY` run's **Check links in README.md** job has been red ([run 32705390996](https://github.com/cvxgrp/cvxcla/actions/runs/32705390996/job/97365257309)). Four links in `README.md` fail:

| Link | Status | Cause |
|---|---|---|
| `https://www.cvxgrp.org/cvxcla/book` | 404 | no such path on the published site |
| `https://www.cvxgrp.org/cvxcla/pdoc/` | 404 | no such path on the published site |
| `https://github.com/cvxgrp/cvxcla/discussions` | 404 | Discussions is not enabled on the repo |
| `https://www.rand.org/pubs/research_memoranda/RM1438.html` | 403 | CloudFront bot block, not a dead link |

## Changes

- **Documentation section** — `mkdocs.yml` serves the docs from the site root (`index.md`, `factor.md`, the two notebooks, the two reports); there is no `book/` and no `pdoc/` any more. The section now lists the pages that actually ship, all verified 200.
- **Quick links** — dropped the Discussions entry. Issues already carries both "Report Bug" and "Request Feature".
- **`.lycheeignore`** (new) — excludes `www.rand.org`. The Markowitz memorandum RM1438 is alive and opens fine in a browser; CloudFront just refuses non-browser clients. lychee reads this file automatically, so no workflow change is needed.

## Verification

Every remaining README link was checked and returns 200; the rand.org host is the only exclusion. The weekly workflow only triggers on schedule/dispatch, so a manual run on this branch confirms the job goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)