### PR TITLE
docs: add the Zenodo DOI badge and a CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,61 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata below."
+title: cvxcla
+abstract: >-
+  A Python implementation of Markowitz's Critical Line Algorithm (CLA), which
+  computes the entire efficient frontier of a portfolio-optimization problem
+  exactly, as a finite list of turning points, under arbitrary linear equality
+  constraints and bounds on the weights. Covariance is consumed through an
+  operator protocol, so dense, Gram and diagonal-plus-low-rank factor models
+  are all traced without ever forming an n-by-n matrix. The same parametric
+  active-set engine also traces the LASSO regularisation path, including
+  general inequality constraints and the non-negative LASSO.
+type: software
+authors:
+  - given-names: Thomas
+    family-names: Schmelzer
+    email: thomas.schmelzer@gmail.com
+    affiliation: Jebel Quant Research
+  - given-names: Philipp
+    family-names: Schiele
+    email: pschiele@stanford.edu
+repository-code: "https://github.com/cvxgrp/cvxcla"
+url: "https://www.cvxgrp.org/cvxcla"
+license: MIT
+version: 2.0.0
+date-released: "2026-08-31"
+doi: 10.5281/zenodo.22209208
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.22209208
+    description: >-
+      Concept DOI, which always resolves to the most recent release. Cite this
+      when referring to cvxcla in general.
+  - type: doi
+    value: 10.5281/zenodo.22209209
+    description: >-
+      Version DOI for release v2.0.0. Cite this when the exact release used
+      matters for reproducibility.
+keywords:
+  - portfolio optimization
+  - critical line algorithm
+  - efficient frontier
+  - Markowitz
+  - quadratic programming
+  - active-set method
+  - parametric programming
+  - LASSO
+  - convex optimization
+  - Python
+references:
+  - type: report
+    title: >-
+      The Optimization of Quadratic Functions Subject to Linear Constraints
+    authors:
+      - given-names: Harry
+        family-names: Markowitz
+    institution:
+      name: RAND Corporation
+    number: RM-1438
+    year: 1955
+    url: "https://www.rand.org/pubs/research_memoranda/RM1438.html"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/cvxcla?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/cvxcla)
 [![Coverage](https://www.cvxgrp.org/cvxcla/coverage-badge.svg)](https://www.cvxgrp.org/cvxcla/reports/html-coverage/index.html)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22209209.svg)](https://doi.org/10.5281/zenodo.22209209)
 
 ---
 


### PR DESCRIPTION
Makes the repo citable: adds the Zenodo DOI badge to the README, and a
`CITATION.cff` so GitHub renders a "Cite this repository" panel.

## 1. README badge

```markdown
[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.22209209.svg)](https://doi.org/10.5281/zenodo.22209209)
```

Both URLs were checked before committing: the badge SVG returns `200
image/svg+xml`, and `https://doi.org/10.5281/zenodo.22209209` resolves (200) to
`https://zenodo.org/records/22209209` — record title `cvxgrp/cvxcla: v2.0.0`,
resource type Software. The weekly link check should stay green.

## 2. `CITATION.cff`

Validated with `cffconvert --validate` against CFF schema 1.2.0. It renders as:

```
Schmelzer T., Schiele P. (2026). cvxcla (version 2.0.0).
DOI: 10.5281/zenodo.22209208 URL: https://www.cvxgrp.org/cvxcla
```

Every field is taken from something already in the repo or from the Zenodo
record — nothing invented:

| Field | Source |
| --- | --- |
| `authors` | the two entries in `[project].authors` in `pyproject.toml` |
| `version`, `date-released` | `2.0.0`, and the `v2.0.0` tag date (`2026-08-31`), which matches Zenodo's publication date |
| `license` | `MIT`, from `[project].license` |
| `repository-code`, `url` | `[project.urls]` and the documentation site |
| `abstract` | condensed from the README overview |
| `references` | Markowitz's RM-1438, already linked in the README |

Left deliberately blank: **ORCIDs**. CFF supports them and they materially
improve author disambiguation, but I have no verified value for either author
and would not guess one. Worth adding by hand.

## Two things to confirm before merging

**Authorship.** `pyproject.toml` declares two authors — Thomas Schmelzer and
Philipp Schiele — and `CITATION.cff` follows it. The **Zenodo record credits
only Thomas Schmelzer**, and `git shortlog` shows no commits from Philipp
Schiele in this repository. If the two-author list is right, the Zenodo record's
creator list is the thing that needs correcting; if the citation should name one
author, this file needs the edit instead. Either way the two should agree, and
which one is authoritative is not something the repo can settle.

**Which DOI goes where.** `10.5281/zenodo.22209209` is the *version* DOI, minted
for the v2.0.0 deposit; `10.5281/zenodo.22209208` is the *concept* DOI, which
always resolves to the newest release. This PR currently:

- uses the **version DOI in the README badge** (as requested), so the badge
  permanently reads `v2.0.0` and needs a manual edit at every release;
- uses the **concept DOI as the primary `doi:` in `CITATION.cff`**, with both
  listed under `identifiers` and labelled, so a citation stays correct as
  releases accumulate while the exact-release DOI is still recorded.

If you would rather the badge track the latest release too, it is a
one-character change (`…209` → `…208`) in both the image URL and the link
target.
