### PR TITLE
chore: update rhiza to v1.8.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.8.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.8.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.8.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.8.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.8.0
     secrets: inherit

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -67,7 +67,10 @@
 #   - SBOM attestations generated for supply chain transparency (public repos only)
 #
 # 📄 Requirements:
-#   - pyproject.toml with top-level version field (for Python packages)
+#   - pyproject.toml declaring a version (for Python packages): either written as
+#     `[project].version`, or listed in `[project].dynamic` for the build backend to
+#     derive from the VCS (hatch-vcs, setuptools-scm). A derived version is checked
+#     against the tag on the built distribution rather than in the file.
 #   - Package registered on PyPI as Trusted Publisher (for PyPI publishing)
 #   - Conda recipe generation is optional and only runs when PyPI publishing is active
 #   - PUBLISH_DEVCONTAINER variable set to "true" (for devcontainer publishing)
@@ -270,16 +273,47 @@ jobs:
 
       - name: Verify version matches tag
         if: hashFiles('pyproject.toml') != ''
+        env:
+          # Read from the environment, not interpolated into the script: that is what
+          # lets tests/api/test_release_version_verification.py run this exact shell
+          # against purpose-built projects instead of asserting on the step's name.
+          TAG: ${{ needs.tag.outputs.tag }}
         run: |
-          TAG_VERSION="${{ needs.tag.outputs.tag }}"
-          TAG_VERSION=${TAG_VERSION#v}
-          PROJECT_VERSION=$(uv version --short)
+          TAG_VERSION="${TAG#v}"
 
           # Normalize tag version to PEP 440 format for comparison.
           # Tags use semver format (e.g., 0.11.1-beta.1) while uv version --short
           # returns PEP 440 normalized format (e.g., 0.11.1b1).
           NORMALIZED_TAG=$(uv run --with packaging --no-project python3 -c "from packaging.version import Version; print(Version('$TAG_VERSION'))")
 
+          # A project may derive its version from the VCS rather than write one: PEP 621's
+          # `dynamic = ["version"]` with a backend plugin such as hatch-vcs. There is then
+          # no number in the file to compare, and `uv version --short` does not return a
+          # differing one -- it exits 2 ("We cannot get or set dynamic project versions"),
+          # which would fail every release of such a project. The tag-versus-version check
+          # moves to "Verify built distribution matches the tag" below, which is where a
+          # derived version can actually be wrong.
+          DYNAMIC=$(uv run --with tomli --no-project python3 -c "
+          import pathlib, tomli
+          project = tomli.loads(pathlib.Path('pyproject.toml').read_text()).get('project') or {}
+          print('dynamic' if 'version' in (project.get('dynamic') or []) else 'written')")
+
+          case "$DYNAMIC" in
+            dynamic)
+              echo "[project].version is dynamic: derived from the VCS, so there is no written number to compare against $NORMALIZED_TAG. The distribution built below is checked against the tag instead."
+              exit 0
+              ;;
+            written)
+              ;;
+            *)
+              # Never assume "written": that would call `uv version --short` on a dynamic
+              # project and fail with an error about the probe, not about the release.
+              echo "::error::Could not tell whether [project].version is written or dynamic (probe returned '$DYNAMIC')"
+              exit 1
+              ;;
+          esac
+
+          PROJECT_VERSION=$(uv version --short)
           if [[ "$PROJECT_VERSION" != "$NORMALIZED_TAG" ]]; then
             echo "::error::Version mismatch: pyproject.toml has '$PROJECT_VERSION' but tag is '$NORMALIZED_TAG' (from tag '$TAG_VERSION')"
             exit 1
@@ -300,6 +334,52 @@ jobs:
         run: |
           printf "[INFO] Building package...\n"
           uv build
+
+      - name: Verify built distribution matches the tag
+        if: steps.buildable.outputs.buildable == 'true'
+        env:
+          TAG: ${{ needs.tag.outputs.tag }}
+        run: |
+          # The only place a version *derived* from the VCS can be caught being wrong.
+          # hatch-vcs and setuptools-scm fall back rather than fail, so a checkout that
+          # cannot see the tag builds `0.1.dev1+g<sha>` and publishes it under a green
+          # tick with no error anywhere -- which is why the checkout above uses
+          # fetch-depth: 0. Runs for a written version too: it costs one filename parse
+          # and closes the gap between what the step above read and what `uv build`
+          # actually produced.
+          TAG_VERSION="${TAG#v}"
+          uv run --with packaging --no-project python3 -c '
+          import pathlib
+          import sys
+
+          from packaging.utils import parse_sdist_filename, parse_wheel_filename
+          from packaging.version import Version
+
+          expected = Version(sys.argv[1])
+          dist = pathlib.Path("dist")
+          built = sorted(dist.glob("*.whl")) + sorted(dist.glob("*.tar.gz"))
+          if not built:
+              print("::error::uv build produced no distribution in dist/ -- there is nothing to publish or verify")
+              sys.exit(1)
+
+          mismatched = []
+          for artifact in built:
+              parse = parse_wheel_filename if artifact.name.endswith(".whl") else parse_sdist_filename
+              found = parse(artifact.name)[1]
+              print(f"{artifact.name}: {found}")
+              if found != expected:
+                  mismatched.append(f"{artifact.name} carries {found}")
+
+          if mismatched:
+              print(
+                  f"::error::Built distribution does not carry the release version {expected}: "
+                  + ", ".join(mismatched)
+                  + ". A version derived from the VCS falls back to a dev version when the tag "
+                  "is not visible to the build -- check the checkout depth and that tags were fetched."
+              )
+              sys.exit(1)
+          print(f"Built distribution verified at {expected}")
+          ' "$TAG_VERSION"
 
       - name: Install Python for SBOM generation
         if: hashFiles('pyproject.toml') != ''

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.8.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.7.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.8.0
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         groups: ["fast"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.16.5'
+    rev: 'v0.16.6'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -46,7 +46,7 @@ repos:
         groups: ["python", "format", "fast"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.49.0
+    rev: v0.49.1
     hooks:
       - id: markdownlint
         args: ["--disable", "MD013"]
@@ -90,7 +90,7 @@ repos:
         groups: ["security", "slow"]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.9
+    rev: 0.12.10
     hooks:
       - id: uv-lock
         groups: ["python", "fast"]

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 2955fe77885ad31532579eea11905f4aefb17260
+sha: 371314b93a460e27d648c87377e8fa252bd92d15
 repo: jebel-quant/rhiza
 host: github
-ref: v1.7.2
+ref: v1.8.0
 include: []
 exclude:
 - LICENSE
@@ -41,5 +41,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-09-02T06:48:38Z'
+synced_at: '2026-09-08T07:21:19Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.7.2"
+ref: "v1.8.0"
 
 profiles:
   - github-project

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Repo-specific *tasks* go in a `rhiza_task.tasks` entry point, repo-specific *targets* in
 # `local.mk`, which core deliberately does not ignore. Nothing goes below the shim: this
 # file is synced, so the next `/rhiza:update` overwrites whatever was appended to it.
-RHIZA_TASK ?= rhiza-task@1.5.0
+RHIZA_TASK ?= rhiza-task@1.7.0
 
 # uv cannot be delegated, because uv is what runs the CLI. Prepended so a machine carrying
 # an older uv still resolves the pin, exported because task bodies shell out to bare `uv`.


### PR DESCRIPTION
Template sync from `jebel-quant/rhiza`: **v1.7.2 → v1.8.0**.

- 11 template-owned files changed (8 workflows, `.pre-commit-config.yaml`, `Makefile`, `.rhiza/template.lock`) plus the `ref` bump in `.rhiza/template.yml`.
- No merge conflicts — the sync applied cleanly.
- Nothing left unstaged: no repo-owned file was touched.

No gates were run — run `/rhiza:quality` for a scorecard.
